### PR TITLE
Include branch and PR number in package versioning, and include build…

### DIFF
--- a/ci/set_version_from_git.ps1
+++ b/ci/set_version_from_git.ps1
@@ -5,6 +5,8 @@ $versions = & ($ciPath + "discover_version.ps1")
 
 if ($versions)
 {
+    $prNumber = $env:APPVEYOR_PULL_REQUEST_NUMBER
+
     # Build new version string
     $newVersion = "$($versions.InfoVersion.Major).$($versions.InfoVersion.Minor).$($versions.InfoVersion.Patch)"
 
@@ -12,6 +14,34 @@ if ($versions)
 	$assembly_version = "$newVersion.0"
 	$fullVersion = "$newVersion.$env:APPVEYOR_BUILD_NUMBER"
     $semVer1 = $fullVersion
+
+    $branch = $env:APPVEYOR_REPO_BRANCH
+    if ($branch)
+    {
+        $postfix = ""
+        if ($branch -eq "master")
+        {
+            $postfix = "beta"
+        } elseif ($branch -eq "develop")
+        {
+            $postfix = "alpha"
+        } elseif ($branch.StartsWith("release")) {
+        } else {
+            $postfix = $branch -replace "[^0-9A-Za-z\-]","-"
+        }
+
+        if ($postfix)
+        {
+            $package_version += "-" + $postfix + ".build." + $env:APPVEYOR_BUILD_NUMBER
+            $semVer1 += "-" + $postfix + ".build." + $env:APPVEYOR_BUILD_NUMBER
+        }
+    }
+
+    if ($prNumber)
+    {
+        $package_version += "-PR" + $prNumber
+        $semVer1 += "-PR" + $prNumber
+    }
 
     if ($versions.InfoVersion.Suffix)
     {
@@ -21,7 +51,7 @@ if ($versions)
 
 	$informational_version = $semVer1
 
-    Write-Host "Build v$semVer1 will be building package version v$package_version"
+    Write-Host "Build v$fullVersion will be building package version v$package_version"
 
     Try
     {


### PR DESCRIPTION
Include branch and PR number in package versioning, and include buildnumber in CI job version when not a release, allowing use of nuget project feed.

Should switch to GitVersion at some point, but this will do for now.