### PR TITLE
Add builders for BBAN and IBAN.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## v4.x - pending
 
 - Upgraded registry to September '20 release 88 (added Libya (LY))
+- Added `IbanBuilder` and `BbanBuilder` types.
 
 ## v4.1.0
 

--- a/src/IbanNet/Builders/BankAccountBuilderException.cs
+++ b/src/IbanNet/Builders/BankAccountBuilderException.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+namespace IbanNet.Builders
+{
+    /// <summary>
+    /// The exception that is thrown when building a bank account number fails.
+    /// </summary>
+#if SERIALIZABLE
+    [Serializable]
+#endif
+    public class BankAccountBuilderException : InvalidOperationException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BankAccountBuilderException" />.
+        /// </summary>
+        public BankAccountBuilderException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BankAccountBuilderException" /> using specified message.
+        /// </summary>
+        /// <param name="message">The error message.</param>
+        public BankAccountBuilderException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BankAccountBuilderException" /> class using specified message and inner exception.
+        /// </summary>
+        /// <param name="message">The error message.</param>
+        /// <param name="innerException">The inner exception.</param>
+        public BankAccountBuilderException(string message, Exception? innerException)
+            : base(message, innerException)
+        {
+        }
+
+#if SERIALIZABLE
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BankAccountBuilderException" /> with serialized data.
+        /// </summary>
+        /// <param name="info">The object that holds the serialized data.</param>
+        /// <param name="context">The contextual information about the source or destination.</param>
+        protected BankAccountBuilderException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context)
+        {
+        }
+#endif
+    }
+}

--- a/src/IbanNet/Builders/BbanBuilder.cs
+++ b/src/IbanNet/Builders/BbanBuilder.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Globalization;
+using IbanNet.Extensions;
+using IbanNet.Registry;
+
+namespace IbanNet.Builders
+{
+    /// <summary>
+    /// A builder to build national bank account numbers (BBAN).
+    /// <para>
+    /// The builder does not ensure validity of the returned BBAN. Use a validator on the built BBAN to ensure validity.
+    /// </para>
+    /// </summary>
+    public sealed class BbanBuilder : IBankAccountBuilder
+    {
+        private IbanCountry? _country;
+        private char[]? _bankAccountNumber;
+        private bool _bankAccountNumberPadding = true;
+        private char[]? _bankIdentifier;
+        private bool _bankIdentifierPadding = true;
+        private char[]? _branchIdentifier;
+        private bool _branchIdentifierPadding = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BbanBuilder"/> class.
+        /// </summary>
+        // ReSharper disable once EmptyConstructor
+        public BbanBuilder()
+        {
+        }
+
+        /// <inheritdoc />
+        public IBankAccountBuilder WithCountry(IbanCountry country)
+        {
+            _country = country ?? throw new ArgumentNullException(nameof(country));
+            return this;
+        }
+
+        /// <inheritdoc />
+        public IBankAccountBuilder WithBankAccountNumber(string bankAccountNumber, bool enablePadding = true)
+        {
+            // ReSharper disable once ConstantConditionalAccessQualifier
+            _bankAccountNumber = bankAccountNumber?.ToCharArray() ?? throw new ArgumentNullException(nameof(bankAccountNumber));
+            _bankAccountNumberPadding = enablePadding;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public IBankAccountBuilder WithBankIdentifier(string bankIdentifier, bool enablePadding = true)
+        {
+            // ReSharper disable once ConstantConditionalAccessQualifier
+            _bankIdentifier = bankIdentifier?.ToCharArray();
+            _bankIdentifierPadding = enablePadding;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public IBankAccountBuilder WithBranchIdentifier(string branchIdentifier, bool enablePadding = true)
+        {
+            // ReSharper disable once ConstantConditionalAccessQualifier
+            _branchIdentifier = branchIdentifier?.ToCharArray();
+            _branchIdentifierPadding = enablePadding;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public string Build()
+        {
+            char[] buffer;
+            try
+            {
+                if (_country is null)
+                {
+                    throw new InvalidOperationException("The country is required.");
+                }
+
+                buffer = new char[_country.Bban.Length].Fill('0');
+
+                CopyToBuffer(_bankAccountNumber, buffer, _country.Bban, _bankAccountNumberPadding, _country.TwoLetterISORegionName, nameof(_country.Bban));
+                CopyToBuffer(_bankIdentifier, buffer, _country.Bank, _bankIdentifierPadding, _country.TwoLetterISORegionName, nameof(_country.Bank));
+                CopyToBuffer(_branchIdentifier, buffer, _country.Branch, _branchIdentifierPadding, _country.TwoLetterISORegionName, nameof(_country.Branch));
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new BankAccountBuilderException(Resources.Exception_Builder_The_BBAN_cannot_be_built, ex);
+            }
+
+            return new string(buffer);
+        }
+
+        private static void CopyToBuffer(char[]? source, char[] destination, IStructureSection structure, bool padding, string countryCode, string name)
+        {
+            const int relativeToIbanPos = 4;
+
+            if (structure.Length == 0 && source?.Length > 0)
+            {
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_Builder_A_value_for_0_is_not_supported_for_country_code_1, name, countryCode));
+            }
+
+            CopyToBuffer(
+                source,
+                destination,
+                structure.Position - relativeToIbanPos,
+                structure.Length,
+                padding);
+        }
+
+        private static void CopyToBuffer(char[]? source, char[] destination, int destinationPosition, int count, bool padding)
+        {
+            if (count == 0 || !(source?.Length > 0))
+            {
+                return;
+            }
+
+            int srcPos = count - source.Length;
+            if (srcPos < 0 || srcPos > 0 && !padding)
+            {
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.Exception_Builder_The_value_0_does_not_have_the_correct_length_of_1, new string(source), count));
+            }
+
+            source.CopyTo(destination, destinationPosition + srcPos);
+        }
+    }
+}

--- a/src/IbanNet/Builders/BuilderExtensions.cs
+++ b/src/IbanNet/Builders/BuilderExtensions.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using IbanNet.Registry;
+
+namespace IbanNet.Builders
+{
+    /// <summary>
+    /// Extensions for builders.
+    /// </summary>
+    public static class BuilderExtensions
+    {
+        /// <summary>
+        /// Gets an <see cref="IbanBuilder"/> for this country.
+        /// </summary>
+        /// <param name="ibanCountry">The country.</param>
+        /// <returns>An instance of <see cref="IbanBuilder"/> for the country specified in <paramref name="ibanCountry"/>.</returns>
+        public static IbanBuilder GetIbanBuilder(this IbanCountry ibanCountry)
+        {
+            return (IbanBuilder)new IbanBuilder().WithCountry(ibanCountry);
+        }
+
+        /// <summary>
+        /// Gets an <see cref="BbanBuilder"/> for this country.
+        /// </summary>
+        /// <param name="ibanCountry">The country.</param>
+        /// <returns>An instance of <see cref="BbanBuilder"/> for the country specified in <paramref name="ibanCountry"/>.</returns>
+        public static BbanBuilder GetBbanBuilder(this IbanCountry ibanCountry)
+        {
+            return (BbanBuilder)new BbanBuilder().WithCountry(ibanCountry);
+        }
+
+        /// <summary>
+        /// Adds the specified <paramref name="countryCode"/> to the builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="countryCode">The country code.</param>
+        /// <param name="registry">The IBAN registry to resolve the country from.</param>
+        /// <returns>The builder to continue chaining.</returns>
+        public static IBankAccountBuilder WithCountry(this IBankAccountBuilder builder, string countryCode, IIbanRegistry registry)
+        {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (registry is null)
+            {
+                throw new ArgumentNullException(nameof(registry));
+            }
+
+            if (!registry.TryGetValue(countryCode, out IbanCountry country))
+            {
+                throw new ArgumentException(Resources.ArgumentException_Builder_The_country_code_is_not_registered, nameof(countryCode));
+            }
+
+            return builder.WithCountry(country);
+        }
+    }
+}

--- a/src/IbanNet/Builders/IBankAccountBuilder.cs
+++ b/src/IbanNet/Builders/IBankAccountBuilder.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using IbanNet.Registry;
+
+namespace IbanNet.Builders
+{
+    /// <summary>
+    /// A builder to build bank account numbers.
+    /// </summary>
+    public interface IBankAccountBuilder : IFluentInterface
+    {
+        /// <summary>
+        /// Adds the specified <paramref name="country"/> to the builder.
+        /// </summary>
+        /// <param name="country">The country.</param>
+        /// <returns>The builder to continue chaining.</returns>
+        IBankAccountBuilder WithCountry(IbanCountry country);
+
+        /// <summary>
+        /// Adds the specified <paramref name="bankIdentifier"/> to the builder.
+        /// </summary>
+        /// <param name="bankIdentifier">The bank identifier.</param>
+        /// <param name="enablePadding"><see langword="true"/> to enable automatic left padding with '0' if a value is too short, <see langword="false"/> to disable padding and throw exceptions if a value is too short.</param>
+        /// <returns>The builder to continue chaining.</returns>
+        IBankAccountBuilder WithBankIdentifier(string bankIdentifier, bool enablePadding = true);
+
+        /// <summary>
+        /// Adds the specified <paramref name="branchIdentifier"/> to the builder.
+        /// </summary>
+        /// <param name="branchIdentifier">The branch identifier.</param>
+        /// <param name="enablePadding"><see langword="true"/> to enable automatic left padding with '0' if a value is too short, <see langword="false"/> to disable padding and throw exceptions if a value is too short.</param>
+        /// <returns>The builder to continue chaining.</returns>
+        IBankAccountBuilder WithBranchIdentifier(string branchIdentifier, bool enablePadding = true);
+
+        /// <summary>
+        /// Adds the specified <paramref name="bankAccountNumber"/> to the builder.
+        /// </summary>
+        /// <param name="bankAccountNumber">The bank account number.</param>
+        /// <param name="enablePadding"><see langword="true"/> to enable automatic left padding with '0' if a value is too short, <see langword="false"/> to disable padding and throw exceptions if a value is too short.</param>
+        /// <returns>The builder to continue chaining.</returns>
+        IBankAccountBuilder WithBankAccountNumber(string bankAccountNumber, bool enablePadding = true);
+
+        /// <summary>
+        /// Creates the bank account number.
+        /// </summary>
+        /// <returns>The bank account number.</returns>
+        /// <exception cref="BankAccountBuilderException">Thrown when bank account number cannot be built.</exception>
+        string Build();
+    }
+}

--- a/src/IbanNet/Builders/IbanBuilder.cs
+++ b/src/IbanNet/Builders/IbanBuilder.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using IbanNet.CheckDigits.Calculators;
+using IbanNet.Registry;
+
+namespace IbanNet.Builders
+{
+    /// <summary>
+    /// A builder to build international bank account numbers (IBAN).
+    /// <para>
+    /// The builder does not ensure validity of the returned IBAN. The check digits are valid, but the characters used may be invalid. Use a validator on the built IBAN to ensure validity.
+    /// </para>
+    /// </summary>
+    public sealed class IbanBuilder : IBankAccountBuilder
+    {
+        private const int InverseMod97PlusExpectedCheckDigit = 97 + 1;
+
+        private readonly BbanBuilder _bbanBuilder;
+        private readonly Mod97CheckDigitsCalculator _checkDigitCalculator;
+
+        private IbanCountry _country = null!;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IbanBuilder"/> class.
+        /// </summary>
+        public IbanBuilder()
+        {
+            _bbanBuilder = new BbanBuilder();
+            _checkDigitCalculator = new Mod97CheckDigitsCalculator();
+        }
+
+        /// <inheritdoc />
+        public IBankAccountBuilder WithCountry(IbanCountry country)
+        {
+            _bbanBuilder.WithCountry(country);
+            _country = country;
+            return this;
+        }
+
+        /// <inheritdoc />
+        public IBankAccountBuilder WithBankAccountNumber(string bankAccountNumber, bool enablePadding = true)
+        {
+            _bbanBuilder.WithBankAccountNumber(bankAccountNumber, enablePadding);
+            return this;
+        }
+
+        /// <inheritdoc />
+        public IBankAccountBuilder WithBankIdentifier(string bankIdentifier, bool enablePadding = true)
+        {
+            _bbanBuilder.WithBankIdentifier(bankIdentifier, enablePadding);
+            return this;
+        }
+
+        /// <inheritdoc />
+        public IBankAccountBuilder WithBranchIdentifier(string branchIdentifier, bool enablePadding = true)
+        {
+            _bbanBuilder.WithBranchIdentifier(branchIdentifier, enablePadding);
+            return this;
+        }
+
+        /// <inheritdoc />
+        public string Build()
+        {
+            string countryCode;
+            string bban;
+            char[] buffer;
+
+            try
+            {
+                bban = _bbanBuilder.Build();
+
+                countryCode = _country.TwoLetterISORegionName;
+                buffer = new char[_country.Iban.Length];
+
+                // Compute check digit.
+                CopyToBuffer(buffer,
+                    countryCode,
+                    0,
+                    bban,
+                    countryCodePos: bban.Length,
+                    checkDigitPos: bban.Length + countryCode.Length,
+                    bbanPos: 0);
+            }
+            catch (BankAccountBuilderException ex)
+            {
+                throw new BankAccountBuilderException(Resources.Exception_Builder_The_IBAN_cannot_be_built, ex.InnerException);
+            }
+
+            // Return IBAN.
+            int checkDigits = InverseMod97PlusExpectedCheckDigit - _checkDigitCalculator.Compute(buffer);
+            CopyToBuffer(buffer, countryCode, checkDigits, bban);
+
+            return new string(buffer);
+        }
+
+        private static void CopyToBuffer
+        (
+            char[] buffer,
+            string countryCode,
+            int checkDigits,
+            string bban,
+            int countryCodePos = 0,
+            int checkDigitPos = 2,
+            int bbanPos = 4)
+        {
+            countryCode.CopyTo(0, buffer, countryCodePos, countryCode.Length);
+            buffer[checkDigitPos] = (char)((checkDigits / 10) + '0');
+            buffer[checkDigitPos + 1] = (char)((checkDigits % 10) + '0');
+            bban.CopyTo(0, buffer, bbanPos, bban.Length);
+        }
+    }
+}

--- a/src/IbanNet/Extensions/ArrayExtensions.cs
+++ b/src/IbanNet/Extensions/ArrayExtensions.cs
@@ -1,0 +1,28 @@
+﻿namespace IbanNet.Extensions
+{
+    internal static class ArrayExtensions
+    {
+        /// <summary>
+        /// Fills each <paramref name="array"/> element with the value specified in <paramref name="fillWith"/>
+        /// </summary>
+        /// <typeparam name="T">The array element type.</typeparam>
+        /// <param name="array">The array to fill.</param>
+        /// <param name="fillWith">The element to fill the array with.</param>
+        /// <returns>The filled array.</returns>
+        public static T[] Fill<T>(this T[] array, T fillWith)
+        {
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+            if (array is null)
+            {
+                return null!;
+            }
+
+            for (int i = 0; i < array.Length; ++i)
+            {
+                array[i] = fillWith;
+            }
+
+            return array;
+        }
+    }
+}

--- a/src/IbanNet/Resources.Designer.cs
+++ b/src/IbanNet/Resources.Designer.cs
@@ -62,6 +62,15 @@ namespace IbanNet {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The country code is not registered..
+        /// </summary>
+        internal static string ArgumentException_Builder_The_country_code_is_not_registered {
+            get {
+                return ResourceManager.GetString("ArgumentException_Builder_The_country_code_is_not_registered", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid country code. must be exactly two characters long..
         /// </summary>
         internal static string ArgumentException_Invalid_country_code {
@@ -121,6 +130,42 @@ namespace IbanNet {
         internal static string ArgumentException_ValidationMethod_is_invalid {
             get {
                 return ResourceManager.GetString("ArgumentException_ValidationMethod_is_invalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A value for &apos;{0}&apos; is not supported for country code {1}..
+        /// </summary>
+        internal static string Exception_Builder_A_value_for_0_is_not_supported_for_country_code_1 {
+            get {
+                return ResourceManager.GetString("Exception_Builder_A_value_for_0_is_not_supported_for_country_code_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The BBAN cannot be built..
+        /// </summary>
+        internal static string Exception_Builder_The_BBAN_cannot_be_built {
+            get {
+                return ResourceManager.GetString("Exception_Builder_The_BBAN_cannot_be_built", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The IBAN cannot be built..
+        /// </summary>
+        internal static string Exception_Builder_The_IBAN_cannot_be_built {
+            get {
+                return ResourceManager.GetString("Exception_Builder_The_IBAN_cannot_be_built", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The value &apos;{0}&apos; does not have the correct length of {1}..
+        /// </summary>
+        internal static string Exception_Builder_The_value_0_does_not_have_the_correct_length_of_1 {
+            get {
+                return ResourceManager.GetString("Exception_Builder_The_value_0_does_not_have_the_correct_length_of_1", resourceCulture);
             }
         }
         

--- a/src/IbanNet/Resources.resx
+++ b/src/IbanNet/Resources.resx
@@ -149,4 +149,19 @@
     <data name="One_or_more_providers_is_required" xml:space="preserve">
         <value>One or more providers is required.</value>
     </data>
+    <data name="ArgumentException_Builder_The_country_code_is_not_registered" xml:space="preserve">
+        <value>The country code is not registered.</value>
+    </data>
+    <data name="Exception_Builder_The_BBAN_cannot_be_built" xml:space="preserve">
+        <value>The BBAN cannot be built.</value>
+    </data>
+    <data name="Exception_Builder_The_IBAN_cannot_be_built" xml:space="preserve">
+        <value>The IBAN cannot be built.</value>
+    </data>
+    <data name="Exception_Builder_A_value_for_0_is_not_supported_for_country_code_1" xml:space="preserve">
+        <value>A value for '{0}' is not supported for country code {1}.</value>
+    </data>
+    <data name="Exception_Builder_The_value_0_does_not_have_the_correct_length_of_1" xml:space="preserve">
+        <value>The value '{0}' does not have the correct length of {1}.</value>
+    </data>
 </root>

--- a/test/IbanNet.Tests/Builders/BankAccountBuilderTests.cs
+++ b/test/IbanNet.Tests/Builders/BankAccountBuilderTests.cs
@@ -1,0 +1,217 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using IbanNet.Registry;
+using Xunit;
+
+namespace IbanNet.Builders
+{
+    public class BankAccountBuilderTests
+    {
+        [Theory]
+        [InlineData(typeof(BbanBuilder))]
+        [InlineData(typeof(IbanBuilder))]
+        public void Given_null_country_when_adding_it_should_throw(Type builderType)
+        {
+            IBankAccountBuilder builder = CreateBuilder(builderType);
+            IbanCountry country = null;
+
+            // Act
+            // ReSharper disable once AssignNullToNotNullAttribute
+            Action act = () => builder.WithCountry(country);
+
+            // Assert
+            act.Should()
+                .ThrowExactly<ArgumentNullException>()
+                .Which.ParamName.Should()
+                .Be(nameof(country));
+        }
+
+        [Theory]
+        [InlineData(typeof(BbanBuilder))]
+        [InlineData(typeof(IbanBuilder))]
+        public void Given_country_is_not_set_when_building_it_should_throw(Type builderType)
+        {
+            string exSource = builderType.Name.Substring(0, 4).ToUpperInvariant();
+
+            IBankAccountBuilder builder = CreateBuilder(builderType);
+
+            // Act
+            Action act = () => builder.Build();
+
+            // Assert
+            act.Should()
+                .ThrowExactly<BankAccountBuilderException>()
+                .WithMessage($"The {exSource} cannot be built.")
+                .WithInnerException<InvalidOperationException>()
+                .WithMessage("The country is required.");
+        }
+
+        [Theory]
+        [InlineData(typeof(BbanBuilder), "NL", "00000000000000")]
+        [InlineData(typeof(BbanBuilder), "GB", "000000000000000000")]
+        [InlineData(typeof(IbanBuilder), "NL", "NL2200000000000000")]
+        [InlineData(typeof(IbanBuilder), "GB", "GB18000000000000000000")]
+        public void Given_only_country_when_building_it_should_not_throw(Type builderType, string countryCode, string expected)
+        {
+            IBankAccountBuilder builder = CreateBuilder(builderType)
+                .WithCountry(countryCode, IbanRegistry.Default);
+
+            // Act
+            Func<string> act = () => builder.Build();
+
+            // Assert
+            act.Should()
+                .NotThrow()
+                .Which.Should()
+                .Be(expected);
+        }
+
+        [Theory]
+        [InlineData(typeof(BbanBuilder), "NL", "123", "00000000000123")]
+        [InlineData(typeof(BbanBuilder), "GB", "123", "000000000000000123")]
+        [InlineData(typeof(IbanBuilder), "NL", "789", "NL5900000000000789")]
+        [InlineData(typeof(IbanBuilder), "GB", "789", "GB55000000000000000789")]
+        public void Given_bankAccountNumber_when_building_it_should_return_value(Type builderType, string countryCode, string bankAccountNumber, string expected)
+        {
+            IBankAccountBuilder builder = CreateBuilder(builderType)
+                .WithCountry(countryCode, IbanRegistry.Default)
+                .WithBankAccountNumber(bankAccountNumber);
+
+            // Act
+            string actual = builder.Build();
+
+            // Assert
+            actual.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BuilderMethodTestCases))]
+        public void Given_value_is_too_short_and_padding_is_disabled_when_building_it_should_throw(
+            Type builderType,
+            Action<IBankAccountBuilder, string, bool> @delegate
+        )
+        {
+            string exSource = builderType.Name.Substring(0, 4).ToUpperInvariant();
+
+            IBankAccountBuilder builder = CreateBuilder(builderType)
+                .WithCountry("GB", IbanRegistry.Default);
+            @delegate(builder, "1", false);
+
+            // Act
+            Action act = () => builder.Build();
+
+            // Assert
+            act.Should()
+                .ThrowExactly<BankAccountBuilderException>()
+                .WithMessage($"The {exSource} cannot be built.")
+                .WithInnerException<InvalidOperationException>()
+                .WithMessage("The value '1' does not have the correct length of *.");
+        }
+
+        [Theory]
+        [MemberData(nameof(TooShortWithPaddingTestCases))]
+        public void Given_value_is_too_short_and_padding_is_enabled_when_building_it_should_pad_with_zeroes(
+            Type builderType,
+            Action<IBankAccountBuilder, string, bool> @delegate,
+            string countryCode,
+            string value,
+            string expected
+        )
+        {
+            IBankAccountBuilder builder = CreateBuilder(builderType)
+                .WithCountry(countryCode, IbanRegistry.Default);
+            @delegate(builder, value, true);
+
+            // Act
+            Func<string> act = () => builder.Build();
+
+            // Assert
+            act.Should()
+                .NotThrow()
+                .Which.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BuilderMethodTestCases))]
+        public void Given_value_is_too_long_when_building_it_should_throw(
+            Type builderType,
+            Action<IBankAccountBuilder, string, bool> @delegate
+        )
+        {
+            string exSource = builderType.Name.Substring(0, 4).ToUpperInvariant();
+
+            IBankAccountBuilder builder = CreateBuilder(builderType)
+                .WithCountry("GB", IbanRegistry.Default);
+            @delegate(builder, new string('0', 100), false);
+
+            // Act
+            Action act = () => builder.Build();
+
+            // Assert
+            act.Should()
+                .ThrowExactly<BankAccountBuilderException>()
+                .WithMessage($"The {exSource} cannot be built.")
+                .WithInnerException<InvalidOperationException>()
+                .WithMessage("The value '*' does not have the correct length of *.");
+        }
+
+        [Theory]
+        [InlineData(typeof(BbanBuilder))]
+        [InlineData(typeof(IbanBuilder))]
+        public void Given_country_does_not_support_branchIdentifier_when_building_it_should_throw(Type builderType)
+        {
+            string exSource = builderType.Name.Substring(0, 4).ToUpperInvariant();
+
+            IBankAccountBuilder builder = CreateBuilder(builderType)
+                .WithCountry("NL", IbanRegistry.Default)
+                .WithBranchIdentifier("123");
+
+            // Act
+            Action act = () => builder.Build();
+
+            // Assert
+            act.Should()
+                .ThrowExactly<BankAccountBuilderException>()
+                .WithMessage($"The {exSource} cannot be built.")
+                .WithInnerException<InvalidOperationException>()
+                .WithMessage("A value for 'Branch' is not supported for country code NL.");
+        }
+
+        private static IBankAccountBuilder CreateBuilder(Type builderType) => (IBankAccountBuilder)Activator.CreateInstance(builderType);
+
+        public static IEnumerable<object[]> BuilderMethodTestCases()
+        {
+            Type bbanBuilder = typeof(BbanBuilder);
+            Type ibanBuilder = typeof(IbanBuilder);
+            Action<IBankAccountBuilder, string, bool> bankAccount = (b, value, pad) => b.WithBankAccountNumber(value, pad);
+            Action<IBankAccountBuilder, string, bool> branch = (b, value, pad) => b.WithBranchIdentifier(value, pad);
+            Action<IBankAccountBuilder, string, bool> bank = (b, value, pad) => b.WithBankIdentifier(value, pad);
+
+            yield return new object[] { bbanBuilder, bankAccount };
+            yield return new object[] { bbanBuilder, branch };
+            yield return new object[] { bbanBuilder, bank };
+
+            yield return new object[] { ibanBuilder, bankAccount };
+            yield return new object[] { ibanBuilder, branch };
+            yield return new object[] { ibanBuilder, bank };
+        }
+
+        public static IEnumerable<object[]> TooShortWithPaddingTestCases()
+        {
+            Type bbanBuilder = typeof(BbanBuilder);
+            Type ibanBuilder = typeof(IbanBuilder);
+            Action<IBankAccountBuilder, string, bool> bankAccount = (b, value, pad) => b.WithBankAccountNumber(value, pad);
+            Action<IBankAccountBuilder, string, bool> branch = (b, value, pad) => b.WithBranchIdentifier(value, pad);
+            Action<IBankAccountBuilder, string, bool> bank = (b, value, pad) => b.WithBankIdentifier(value, pad);
+
+            yield return new object[] { bbanBuilder, bankAccount, "GB", "1", "000000000000000001" };
+            yield return new object[] { bbanBuilder, branch, "GB", "1", "000000000100000000" };
+            yield return new object[] { bbanBuilder, bank, "GB", "1", "000100000000000000" };
+
+            yield return new object[] { ibanBuilder, bankAccount, "GB", "1", "GB88000000000000000001" };
+            yield return new object[] { ibanBuilder, branch, "GB", "1", "GB62000000000100000000" };
+            yield return new object[] { ibanBuilder, bank, "GB", "1", "GB42000100000000000000" };
+        }
+    }
+}

--- a/test/IbanNet.Tests/Builders/BuilderExtensionsTests.cs
+++ b/test/IbanNet.Tests/Builders/BuilderExtensionsTests.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using IbanNet.Registry;
+using Moq;
+using Xunit;
+
+namespace IbanNet.Builders
+{
+    public class BuilderExtensionsTests
+    {
+        public class GetIbanBuilderTests : BuilderExtensionsTests
+        {
+            [Fact]
+            public void Given_country_when_getting_iban_builder_it_should_return_instance()
+            {
+                var country = new IbanCountry("XX");
+
+                // Act
+                IbanBuilder actual = country.GetIbanBuilder();
+
+                // Assert
+                actual.Should().NotBeNull();
+            }
+
+            [Fact]
+            public void Given_null_country_when_getting_iban_builder_it_should_throw()
+            {
+                IbanCountry country = null;
+
+                // Act
+                // ReSharper disable once AssignNullToNotNullAttribute
+                Action act = () => country.GetIbanBuilder();
+
+                // Assert
+                act.Should()
+                    .ThrowExactly<ArgumentNullException>()
+                    .Which.ParamName.Should()
+                    .Be(nameof(country));
+            }
+        }
+
+        public class GetBbanBuilderTests : BuilderExtensionsTests
+        {
+            [Fact]
+            public void Given_country_when_getting_bban_builder_it_should_return_instance()
+            {
+                var country = new IbanCountry("XX");
+
+                // Act
+                BbanBuilder actual = country.GetBbanBuilder();
+
+                // Assert
+                actual.Should().NotBeNull();
+            }
+
+            [Fact]
+            public void Given_null_country_when_getting_bban_builder_it_should_throw()
+            {
+                IbanCountry country = null;
+
+                // Act
+                // ReSharper disable once AssignNullToNotNullAttribute
+                Action act = () => country.GetBbanBuilder();
+
+                // Assert
+                act.Should()
+                    .ThrowExactly<ArgumentNullException>()
+                    .Which.ParamName.Should()
+                    .Be(nameof(country));
+            }
+        }
+
+        public class WithCountryTests : BuilderExtensionsTests
+        {
+            [Theory]
+            [MemberData(nameof(WithCountryTestCases))]
+            public void Given_invalid_arg_when_getting_builder_with_countryCode_it_should_throw(IBankAccountBuilder builder, string countryCode, IIbanRegistry registry, string expectedParamName)
+            {
+                // Act
+                Action act = () => builder.WithCountry(countryCode, registry);
+
+                // Assert
+                act.Should()
+                    .Throw<ArgumentException>()
+                    .Which.ParamName.Should()
+                    .Be(expectedParamName);
+            }
+
+            [Theory]
+            [InlineData("NL")]
+            [InlineData("GB")]
+            public void When_getting_builder_with_countryCode_it_should_configure_builder(string countryCode)
+            {
+                IBankAccountBuilder builder = new IbanBuilder();
+
+                // Act
+                builder.WithCountry(countryCode, IbanRegistry.Default);
+
+                // Assert
+                string iban = builder.Build();
+                iban.Should().StartWith(countryCode);
+            }
+
+            public static IEnumerable<object[]> WithCountryTestCases()
+            {
+                IBankAccountBuilder builder = Mock.Of<IBankAccountBuilder>();
+                const string countryCode = "NL";
+                IIbanRegistry registry = Mock.Of<IIbanRegistry>();
+
+                IbanCountry other = null;
+                var nl = new IbanCountry(countryCode);
+                Mock.Get(registry).Setup(m => m.TryGetValue(It.IsAny<string>(), out other));
+                Mock.Get(registry).Setup(m => m.TryGetValue("NL", out nl));
+
+                yield return new object[] { null, countryCode, registry, nameof(builder) };
+                yield return new object[] { builder, null, registry, nameof(countryCode) };
+                yield return new object[] { builder, countryCode, null, nameof(registry) };
+                yield return new object[] { builder, "ZZ", registry, nameof(countryCode) };
+            }
+        }
+    }
+}

--- a/test/IbanNet.Tests/Extensions/ArrayExtensionsTests.cs
+++ b/test/IbanNet.Tests/Extensions/ArrayExtensionsTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using FluentAssertions;
+using Xunit;
+
+namespace IbanNet.Extensions
+{
+    public class ArrayExtensionsTests
+    {
+        public class FillTests : ArrayExtensionsTests
+        {
+            [Fact]
+            public void Given_null_array_when_filling_it_should_not_throw_and_return_null()
+            {
+                int[] array = null;
+
+                // Act
+                // ReSharper disable once AssignNullToNotNullAttribute
+                Func<int[]> act = () => array.Fill(1);
+
+                // Assert
+                act.Should().NotThrow().Which.Should().BeNull();
+            }
+
+            [Fact]
+            public void Given_array_when_filling_it_should_not_throw_and_return_null()
+            {
+                int[] array = { 1, 2, 3 };
+                int[] expectedArray = { 4, 4, 4 };
+
+                // Act
+                int[] actual = array.Fill(4);
+
+                // Assert
+                actual.Should().BeEquivalentTo(expectedArray);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds two simple builders for IBAN and BBAN.

- both builders depend on a country code supported by the registry
- ability to auto pad account numbers
- computes valid check digit (IBAN only)

Note that both builders do not ensure actual validity, as you can supply the methods any textual data.

In relation to #21 as a prerequisite to support generating pseudo random account numbers (for testing purposes).