### PR TITLE
feat: Adds an IBAN generator based on patterns functionality

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 image: Visual Studio 2019
 skip_branch_with_pr: true
 configuration: Release
+environment:
+  IGNORE_NORMALISATION_GIT_HEAD_MOVE: 1
 install:
   - choco install gitversion.portable --pre -y
 #  - choco install gitversion.portable -y --version=4.0.0

--- a/src/IbanNet.DependencyInjection.Autofac/IbanNetModule.cs
+++ b/src/IbanNet.DependencyInjection.Autofac/IbanNetModule.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Autofac;
 using Autofac.Builder;
 using Autofac.Core;
+using IbanNet.Registry;
 
 namespace IbanNet.DependencyInjection.Autofac
 {
@@ -65,6 +66,16 @@ namespace IbanNet.DependencyInjection.Autofac
                 .As<IIbanValidator>()
                 .IfNotRegistered(typeof(IIbanValidator))
                 .SingleInstance();
+
+            builder
+                .Register(context =>
+                {
+                    IbanValidatorOptions options = context.Resolve<IbanValidatorOptions>();
+                    return new IbanGenerator(options.Registry);
+                })
+                .As<IIbanGenerator>()
+                .IfNotRegistered(typeof(IIbanGenerator))
+                .InstancePerDependency();
         }
     }
 }

--- a/src/IbanNet.DependencyInjection.ServiceProvider/ServiceCollectionExtensions.cs
+++ b/src/IbanNet.DependencyInjection.ServiceProvider/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using IbanNet.Registry;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -50,6 +51,11 @@ namespace IbanNet.DependencyInjection.ServiceProvider
                 }
 
                 return validator;
+            });
+            services.TryAddTransient<IIbanGenerator>(s =>
+            {
+                IbanValidatorOptions options = s.GetRequiredService<IOptions<IbanValidatorOptions>>().Value;
+                return new IbanGenerator(options.Registry);
             });
 
             return services;

--- a/src/IbanNet/Builders/BuilderExtensions.cs
+++ b/src/IbanNet/Builders/BuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using IbanNet.Registry;
 
 namespace IbanNet.Builders
@@ -9,27 +10,27 @@ namespace IbanNet.Builders
     public static class BuilderExtensions
     {
         /// <summary>
-        /// Gets an <see cref="IbanBuilder"/> for this country.
+        /// Gets an <see cref="IbanBuilder" /> for this country.
         /// </summary>
         /// <param name="ibanCountry">The country.</param>
-        /// <returns>An instance of <see cref="IbanBuilder"/> for the country specified in <paramref name="ibanCountry"/>.</returns>
+        /// <returns>An instance of <see cref="IbanBuilder" /> for the country specified in <paramref name="ibanCountry" />.</returns>
         public static IbanBuilder GetIbanBuilder(this IbanCountry ibanCountry)
         {
             return (IbanBuilder)new IbanBuilder().WithCountry(ibanCountry);
         }
 
         /// <summary>
-        /// Gets an <see cref="BbanBuilder"/> for this country.
+        /// Gets an <see cref="BbanBuilder" /> for this country.
         /// </summary>
         /// <param name="ibanCountry">The country.</param>
-        /// <returns>An instance of <see cref="BbanBuilder"/> for the country specified in <paramref name="ibanCountry"/>.</returns>
+        /// <returns>An instance of <see cref="BbanBuilder" /> for the country specified in <paramref name="ibanCountry" />.</returns>
         public static BbanBuilder GetBbanBuilder(this IbanCountry ibanCountry)
         {
             return (BbanBuilder)new BbanBuilder().WithCountry(ibanCountry);
         }
 
         /// <summary>
-        /// Adds the specified <paramref name="countryCode"/> to the builder.
+        /// Adds the specified <paramref name="countryCode" /> to the builder.
         /// </summary>
         /// <param name="builder">The builder.</param>
         /// <param name="countryCode">The country code.</param>
@@ -49,7 +50,12 @@ namespace IbanNet.Builders
 
             if (!registry.TryGetValue(countryCode, out IbanCountry? country))
             {
-                throw new ArgumentException(Resources.ArgumentException_Builder_The_country_code_is_not_registered, nameof(countryCode));
+                throw new ArgumentException(string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.ArgumentException_The_country_code_0_is_not_registered,
+                        countryCode),
+                    nameof(countryCode)
+                );
             }
 
             return builder.WithCountry(country);

--- a/src/IbanNet/Registry/IIbanGenerator.cs
+++ b/src/IbanNet/Registry/IIbanGenerator.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace IbanNet.Registry
+{
+    /// <summary>
+    /// Describes a way to generate test IBAN's.
+    /// </summary>
+    public interface IIbanGenerator
+    {
+        /// <summary>
+        /// Generates a random IBAN for specified IBAN pattern.
+        /// <para>
+        /// All characters except the country code and IBAN check digits are generated based on the structure defined for a country. The IBAN check digits are subsequently computed based on the generated data.
+        /// </para>
+        /// <para>
+        /// While the IBAN produced will pass validation, it may not be an actual valid bank account and should ONLY be used for testing purposes.
+        /// </para>
+        /// </summary>
+        /// <param name="countryCode">The country code.</param>
+        /// <returns>A new random IBAN for specified <paramref name="countryCode" />.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="countryCode" /> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="countryCode" /> is not found in the registry.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when no BBAN pattern is registered for the <paramref name="countryCode" />.</exception>
+        Iban Generate(string countryCode);
+    }
+}

--- a/src/IbanNet/Registry/IbanGenerator.cs
+++ b/src/IbanNet/Registry/IbanGenerator.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using IbanNet.Builders;
+using IbanNet.Registry.Parsing;
+
+namespace IbanNet.Registry
+{
+    /// <summary>
+    /// A generator to create random IBAN's.
+    /// </summary>
+    public class IbanGenerator : IIbanGenerator
+    {
+        private readonly IIbanRegistry _registry;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IbanGenerator" /> class.
+        /// </summary>
+        public IbanGenerator()
+            : this (IbanRegistry.Default)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IbanGenerator" /> class using specified <paramref name="registry" />.
+        /// </summary>
+        /// <param name="registry">The registry containing the IBAN country definitions.</param>
+        public IbanGenerator(IIbanRegistry registry)
+        {
+            _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        }
+
+        /// <inheritdoc />
+        public Iban Generate(string countryCode)
+        {
+            if (countryCode is null)
+            {
+                throw new ArgumentNullException(nameof(countryCode));
+            }
+
+            if (!_registry.TryGetValue(countryCode.ToUpperInvariant(), out IbanCountry? country))
+            {
+                throw new ArgumentException(string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.ArgumentException_The_country_code_0_is_not_registered,
+                        countryCode),
+                    nameof(countryCode)
+                );
+            }
+
+            Pattern? bbanPattern = country.Bban.Pattern;
+            if (bbanPattern is null)
+            {
+                throw new InvalidOperationException($"The country '{countryCode}' does not have a BBAN pattern.");
+            }
+
+            string ibanStr = country
+                .GetIbanBuilder()
+                .WithBankAccountNumber(Generator.Random(bbanPattern))
+                .Build();
+            return new Iban(ibanStr);
+        }
+
+        internal static class Generator
+        {
+            private static readonly Random Rng = new Random(DateTime.UtcNow.Ticks.GetHashCode());
+            private static readonly object RngLock = new object();
+
+            private static readonly AsciiCategory[] LetterCategories = { AsciiCategory.LowercaseLetter, AsciiCategory.UppercaseLetter };
+            private static readonly AsciiCategory[] AlphaNumericCategories = { AsciiCategory.Digit, AsciiCategory.LowercaseLetter, AsciiCategory.UppercaseLetter };
+
+            internal static string Random(Pattern pattern)
+            {
+                return string.Join("", pattern.Tokens.Select(Random));
+            }
+
+            internal static string Random(PatternToken token)
+            {
+                int iterations = token.MaxLength;
+                if (!token.IsFixedLength)
+                {
+                    lock (RngLock)
+                    {
+                        iterations = Rng.Next(token.MinLength, token.MaxLength);
+                    }
+                }
+
+                int charCount = 0;
+                var sb = new StringBuilder(token.MaxLength);
+                do
+                {
+                    AsciiCategory category = token.Category
+                        switch
+                        {
+                            AsciiCategory.Letter => GetRandomCategory(LetterCategories),
+                            AsciiCategory.AlphaNumeric => GetRandomCategory(AlphaNumericCategories),
+                            _ => token.Category
+                        };
+
+                    char charPos;
+                    int charRange;
+                    // ReSharper disable once SwitchStatementHandlesSomeKnownEnumValuesWithDefault
+                    switch (category)
+                    {
+                        case AsciiCategory.Digit:
+                            charPos = '0';
+                            charRange = 10;
+                            break;
+                        case AsciiCategory.LowercaseLetter:
+                            charPos = 'a';
+                            charRange = 26;
+                            break;
+                        case AsciiCategory.UppercaseLetter:
+                            charPos = 'A';
+                            charRange = 26;
+                            break;
+                        case AsciiCategory.Space:
+                            sb.Append(' ');
+                            charCount++;
+                            continue;
+                        default:
+                            // Cannot occur since pattern category is already guarded.
+                            throw new InvalidOperationException();
+                    }
+
+                    int offset;
+                    lock (RngLock)
+                    {
+                        offset = Rng.Next(0, charRange - 1);
+                    }
+
+                    char randomChar = (char)(charPos + offset);
+                    sb.Append(randomChar);
+                    charCount++;
+                } while (charCount < iterations);
+
+                return sb.ToString();
+            }
+
+            private static AsciiCategory GetRandomCategory(IReadOnlyList<AsciiCategory> from)
+            {
+                int i;
+                lock (RngLock)
+                {
+                    i = Rng.Next(0, from.Count - 1);
+                }
+
+                return from[i];
+            }
+        }
+    }
+}

--- a/src/IbanNet/Resources.Designer.cs
+++ b/src/IbanNet/Resources.Designer.cs
@@ -63,15 +63,6 @@ namespace IbanNet {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The country code is not registered..
-        /// </summary>
-        internal static string ArgumentException_Builder_The_country_code_is_not_registered {
-            get {
-                return ResourceManager.GetString("ArgumentException_Builder_The_country_code_is_not_registered", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Invalid country code. must be exactly two characters long..
         /// </summary>
         internal static string ArgumentException_Invalid_country_code {
@@ -86,6 +77,15 @@ namespace IbanNet {
         internal static string ArgumentException_Registry_is_required {
             get {
                 return ResourceManager.GetString("ArgumentException_Registry_is_required", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The country code &apos;{0}&apos; is not registered..
+        /// </summary>
+        internal static string ArgumentException_The_country_code_0_is_not_registered {
+            get {
+                return ResourceManager.GetString("ArgumentException_The_country_code_0_is_not_registered", resourceCulture);
             }
         }
         

--- a/src/IbanNet/Resources.resx
+++ b/src/IbanNet/Resources.resx
@@ -149,8 +149,8 @@
     <data name="One_or_more_providers_is_required" xml:space="preserve">
         <value>One or more providers is required.</value>
     </data>
-    <data name="ArgumentException_Builder_The_country_code_is_not_registered" xml:space="preserve">
-        <value>The country code is not registered.</value>
+    <data name="ArgumentException_The_country_code_0_is_not_registered" xml:space="preserve">
+        <value>The country code '{0}' is not registered.</value>
     </data>
     <data name="Exception_Builder_The_BBAN_cannot_be_built" xml:space="preserve">
         <value>The BBAN cannot be built.</value>

--- a/test/IbanNet.DependencyInjection.Autofac.Tests/Specs/ShouldResolveGeneratorSpec.cs
+++ b/test/IbanNet.DependencyInjection.Autofac.Tests/Specs/ShouldResolveGeneratorSpec.cs
@@ -1,0 +1,11 @@
+﻿using IbanNet.DependencyInjection.Autofac.Fixtures;
+
+namespace IbanNet.DependencyInjection.Autofac.Specs
+{
+    public class ShouldResolveGeneratorSpec : TestHelpers.Specs.ShouldResolveGeneratorSpec
+    {
+        public ShouldResolveGeneratorSpec() : base(new AutofacDependencyInjectionFixture(true))
+        {
+        }
+    }
+}

--- a/test/IbanNet.DependencyInjection.ServiceProvider.Tests/Specs/ShouldResolveGeneratorSpec.cs
+++ b/test/IbanNet.DependencyInjection.ServiceProvider.Tests/Specs/ShouldResolveGeneratorSpec.cs
@@ -1,0 +1,11 @@
+﻿using IbanNet.DependencyInjection.ServiceProvider.Fixtures;
+
+namespace IbanNet.DependencyInjection.ServiceProvider.Specs
+{
+    public class ShouldResolveGeneratorSpec : TestHelpers.Specs.ShouldResolveGeneratorSpec
+    {
+        public ShouldResolveGeneratorSpec() : base(new ServiceProviderDependencyInjectionFixture(true))
+        {
+        }
+    }
+}

--- a/test/IbanNet.Tests/Registry/IbanGeneratorTests.cs
+++ b/test/IbanNet.Tests/Registry/IbanGeneratorTests.cs
@@ -1,0 +1,238 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using IbanNet.Registry.Parsing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace IbanNet.Registry
+{
+    public class IbanGeneratorTests
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+        private readonly IbanValidator _validator;
+        private readonly IbanGenerator _sut;
+
+        public IbanGeneratorTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+            _validator = new IbanValidator();
+            _sut = new IbanGenerator();
+        }
+
+        [Fact]
+        public void Given_null_registry_when_creating_instance_it_should_throw()
+        {
+            IIbanRegistry registry = null;
+
+            // Act
+            // ReSharper disable once AssignNullToNotNullAttribute
+            Func<IbanGenerator> act = () => new IbanGenerator(registry);
+
+            // Assert
+            act.Should()
+                .ThrowExactly<ArgumentNullException>()
+                .Which.ParamName.Should()
+                .Be(nameof(registry));
+        }
+
+        [Fact]
+        public void Given_null_countryCode_when_generating_it_should_throw()
+        {
+            string countryCode = null;
+
+            // Act
+            // ReSharper disable once AssignNullToNotNullAttribute
+            Func<Iban> act = () => _sut.Generate(countryCode);
+
+            // Assert
+            act.Should()
+                .ThrowExactly<ArgumentNullException>()
+                .Which.ParamName.Should()
+                .Be(nameof(countryCode));
+        }
+
+        [Fact]
+        public void Given_that_countryCode_is_unregistered_when_generating_it_should_throw()
+        {
+            const string countryCode = "ZZZ";
+
+            // Act
+            Func<Iban> act = () => _sut.Generate(countryCode);
+
+            // Assert
+            act.Should()
+                .ThrowExactly<ArgumentException>()
+                .WithMessage("*is not registered*")
+                .Which.ParamName.Should()
+                .Be(nameof(countryCode));
+        }
+
+        [Fact]
+        public void Given_that_countryCode_has_no_bban_pattern_when_generating_it_should_throw()
+        {
+            const string countryCode = "ZZ";
+            var registry = new IbanRegistry
+            {
+                Providers =
+                {
+                    new IbanRegistryListProvider(new[] { new IbanCountry(countryCode) })
+                }
+            };
+            var sut = new IbanGenerator(registry);
+
+            // Act
+            Func<Iban> act = () => sut.Generate(countryCode);
+
+            // Assert
+            act.Should()
+                .ThrowExactly<InvalidOperationException>()
+                .WithMessage("*does not have a BBAN pattern*");
+        }
+
+        [Theory]
+        [InlineData("nl")]
+        [InlineData("GB")]
+        [InlineData("fR")]
+        public void Given_mixed_case_country_code_when_generating_it_should_return_valid_iban(string countryCode)
+        {
+            // Act
+            Iban actual = _sut.Generate(countryCode);
+
+            // Assert
+            actual.Should().NotBeNull();
+            _validator.Validate(actual.ToString()).IsValid.Should().BeTrue();
+        }
+
+        [Theory]
+        [MemberData(nameof(GetIbanCountries))]
+        public void When_generating_iban_it_should_return_valid_iban(IbanCountry country)
+        {
+            // Act
+            Iban actual = _sut.Generate(country.TwoLetterISORegionName);
+            _testOutputHelper.WriteLine(actual.ToString());
+
+            // Assert
+            actual.Should().NotBeNull();
+            string iban = actual.ToString();
+            iban.Length.Should().Be(country.Iban.Length);
+            _validator.Validate(iban).IsValid.Should().BeTrue();
+        }
+
+        [Fact]
+        public void When_generating_ibans_it_should_never_generate_same()
+        {
+            const int count = 1000;
+
+            // Act
+            var ibans = new HashSet<Iban>(
+                Enumerable
+                    .Range(0, count)
+                    .Select(_ => _sut.Generate("NL"))
+            );
+
+            // Assert
+            ibans.Should().HaveCount(count);
+        }
+
+        public static IEnumerable<object[]> GetIbanCountries()
+        {
+            return IbanRegistry.Default.Select(country => new object[] { country });
+        }
+
+        public class GeneratorTests
+        {
+            [Fact]
+            public void Given_a_pattern_of_multiple_tokens_when_generating_it_should_return_expected()
+            {
+                Pattern pattern = new FakePattern(new[] { new PatternToken(AsciiCategory.Digit, 4), new PatternToken(AsciiCategory.Space, 1), new PatternToken(AsciiCategory.LowercaseLetter, 4), new PatternToken(AsciiCategory.Space, 1), new PatternToken(AsciiCategory.UppercaseLetter, 4), new PatternToken(AsciiCategory.Space, 1), new PatternToken(AsciiCategory.Letter, 4), new PatternToken(AsciiCategory.Space, 1), new PatternToken(AsciiCategory.AlphaNumeric, 4), });
+
+                // Act
+                string actual = IbanGenerator.Generator.Random(pattern);
+
+                // Assert
+                var segments = actual.Split(' ')
+                    .Select(x => x.ToCharArray())
+                    .ToList();
+
+                segments.Should().HaveCount(5);
+                segments[0].Should().OnlyContain(ch => char.IsDigit(ch));
+                segments[1].Should().OnlyContain(ch => char.IsLower(ch));
+                segments[2].Should().OnlyContain(ch => char.IsUpper(ch));
+                segments[3].Should().OnlyContain(ch => char.IsLetter(ch));
+                segments[4].Should().OnlyContain(ch => char.IsLetterOrDigit(ch));
+            }
+
+            [Theory]
+            [MemberData(nameof(GetRandomPerCategoryTests))]
+            public void Given_a_category_when_generating_token_it_should_only_contain_chars_from_category(AsciiCategory category, Func<char, bool> assert)
+            {
+                var token = new PatternToken(category, 100);
+
+                // Act
+                string actual = IbanGenerator.Generator.Random(token);
+
+                // Assert
+                actual.ToCharArray().Should().OnlyContain(ch => assert(ch));
+            }
+
+            [Theory]
+            [InlineData(AsciiCategory.Space, 1, 100)]
+            [InlineData(AsciiCategory.Digit, 99, 100)]
+            [InlineData(AsciiCategory.LowercaseLetter, 40, 100)]
+            [InlineData(AsciiCategory.UppercaseLetter, 12, 75)]
+            [InlineData(AsciiCategory.Letter, 3, 19)]
+            [InlineData(AsciiCategory.AlphaNumeric, 70, 80)]
+            public void Given_min_and_max_length_differ_when_generating_random_token_it_should_have_random_length(AsciiCategory category, int minLength, int maxLength)
+            {
+                var token = new PatternToken(category, minLength, maxLength);
+
+                // Act
+                string actual = IbanGenerator.Generator.Random(token);
+
+                // Assert
+                actual.ToCharArray()
+                    .Should()
+                    .HaveCountGreaterOrEqualTo(minLength)
+                    .And
+                    .HaveCountLessOrEqualTo(maxLength);
+            }
+
+            [Theory]
+            [InlineData(AsciiCategory.Space, 1)]
+            [InlineData(AsciiCategory.Digit, 99)]
+            [InlineData(AsciiCategory.LowercaseLetter, 40)]
+            [InlineData(AsciiCategory.UppercaseLetter, 12)]
+            [InlineData(AsciiCategory.Letter, 3)]
+            [InlineData(AsciiCategory.AlphaNumeric, 70)]
+            public void Given_length_when_generating_random_token_it_should_have_exact_length(AsciiCategory category, int length)
+            {
+                var token = new PatternToken(category, length);
+
+                // Act
+                string actual = IbanGenerator.Generator.Random(token);
+
+                // Assert
+                actual.Should().HaveLength(length);
+            }
+
+            public static IEnumerable<object[]> GetRandomPerCategoryTests()
+            {
+                yield return new object[] { AsciiCategory.Space, (Func<char, bool>)char.IsWhiteSpace };
+                yield return new object[] { AsciiCategory.Digit, (Func<char, bool>)char.IsDigit };
+                yield return new object[] { AsciiCategory.LowercaseLetter, (Func<char, bool>)char.IsLower };
+                yield return new object[] { AsciiCategory.UppercaseLetter, (Func<char, bool>)char.IsUpper };
+                yield return new object[] { AsciiCategory.Letter, (Func<char, bool>)char.IsLetter };
+                yield return new object[] { AsciiCategory.AlphaNumeric, (Func<char, bool>)char.IsLetterOrDigit };
+            }
+        }
+
+        private class FakePattern : Pattern
+        {
+            public FakePattern(IEnumerable<PatternToken> tokens) : base(tokens)
+            {
+            }
+        }
+    }
+}

--- a/test/TestHelpers/Specs/ShouldResolveGeneratorSpec.cs
+++ b/test/TestHelpers/Specs/ShouldResolveGeneratorSpec.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using FluentAssertions;
+using IbanNet.Registry;
+using TestHelpers.Fixtures;
+using Xunit;
+
+namespace TestHelpers.Specs
+{
+    public abstract class ShouldResolveGeneratorSpec : DiSpec
+    {
+        protected ShouldResolveGeneratorSpec(IDependencyInjectionFixture fixture) : base(fixture)
+        {
+        }
+
+        protected override void Given()
+        {
+            Fixture.Configure(builder => { });
+        }
+
+        [Fact]
+        public void When_resolving_generator_it_should_not_throw()
+        {
+            // Assert
+            Func<IIbanGenerator> act = () => Subject.GetService<IIbanGenerator>();
+
+            // Act
+            act.Should().NotThrow().Which.Should().NotBeNull();
+        }
+    }
+}


### PR DESCRIPTION
See #21 

Use case: (integration) testing with generated IBAN's

- Adds a new class `IbanGenerator` which can be used to generate random IBAN's for testing purposes. Each `Generate()` invocation returns a new random IBAN.
- Only accepts country codes that are registered in the provided registry (via ctor, default is all 'known' IbanNet countries).
- Generates valid IBAN check digits.
- Generates IBAN's that pass validation (guaranteed, but not considering custom rules).
- Registered in dependency injection containers as interface `IIbanGenerator`.

### Inline example
```csharp
var generator = new IbanGenerator();
var randomIban = generator.Generate("NL");
```

### DI example
```csharp
var generator = services.GetRequiredService<IIbanGenerator>();
var randomIban = generator.Generate("GB");
```

Note: does NOT support specifying in specific bank/branch codes. The entire IBAN is completely random (apart from country code/check digits). You can use the generated IBAN icw. the `IbanBuilder` class to generate a new IBAN with bank/branch codes of choice via some extra custom code.
