### PR TITLE
(+semver:breaking) Refactor to FluentValidation v10

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,9 +2,15 @@
 
 ## v5.0.0
 
+## IbanNet
+
 - Removed deprecated contracts/code `IStructureValidationFactory`, `IStructureValidation`, `IStructureSection`. Use the `Pattern` abstraction for custom registry providers.
 - Removed `Iban.Parse`, `Iban.TryParse`, use the `IbanParser` class.
 - Added support for [more countries](./SupportedCountries.md) based on Wikipedia.
+
+### IbanNet.FluentValidation
+
+- Updated to FluentValidation v10.x, dropping .NET 4.6.1.
 
 ## v4.4.1
 

--- a/src/IbanNet.FluentValidation/FluentIbanValidator.cs
+++ b/src/IbanNet.FluentValidation/FluentIbanValidator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentValidation;
 using FluentValidation.Validators;
 
 namespace IbanNet.FluentValidation
@@ -6,35 +7,44 @@ namespace IbanNet.FluentValidation
     /// <summary>
     /// A property validator for international bank account numbers.
     /// </summary>
-    public class FluentIbanValidator : PropertyValidator
+    public class FluentIbanValidator<T> : PropertyValidator<T, string>
     {
         private readonly IIbanValidator _ibanValidator;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FluentIbanValidator" /> class using specified validator.
+        /// Initializes a new instance of the <see cref="FluentIbanValidator{T}" /> class using specified validator.
         /// </summary>
         /// <param name="ibanValidator">The IBAN validator to use.</param>
         public FluentIbanValidator(IIbanValidator ibanValidator)
-            : base(Resources.Not_a_valid_IBAN)
         {
             _ibanValidator = ibanValidator ?? throw new ArgumentNullException(nameof(ibanValidator));
         }
 
         /// <inheritdoc />
-        protected override bool IsValid(PropertyValidatorContext context)
+        protected override string GetDefaultMessageTemplate(string errorCode)
         {
-            if (context?.PropertyValue is null)
+            return Resources.Not_a_valid_IBAN;
+        }
+
+        /// <inheritdoc />
+        public override bool IsValid(ValidationContext<T> context, string value)
+        {
+            if (value is null!)
             {
                 return true;
             }
 
-            ValidationResult result = _ibanValidator.Validate((string)context.PropertyValue);
+            ValidationResult result = _ibanValidator.Validate(value);
             if (result.Error is { })
             {
-                context.MessageFormatter.AppendArgument("Error", result.Error);
+                // ReSharper disable once ConstantConditionalAccessQualifier
+                context?.MessageFormatter.AppendArgument("Error", result.Error);
             }
 
             return result.IsValid;
         }
+
+        /// <inheritdoc />
+        public override string Name => nameof(FluentIbanValidator<object>);
     }
 }

--- a/src/IbanNet.FluentValidation/IbanNet.FluentValidation.csproj
+++ b/src/IbanNet.FluentValidation/IbanNet.FluentValidation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netstandard2.0;netstandard2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="9.0.1" />
+    <PackageReference Include="FluentValidation" Version="10.2.3" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/IbanNet.FluentValidation/RuleBuilderExtensions.cs
+++ b/src/IbanNet.FluentValidation/RuleBuilderExtensions.cs
@@ -26,7 +26,7 @@ namespace IbanNet.FluentValidation
                 throw new ArgumentNullException(nameof(ruleBuilder));
             }
 
-            return ruleBuilder.SetValidator(new FluentIbanValidator(ibanValidator));
+            return ruleBuilder.SetValidator(new FluentIbanValidator<T>(ibanValidator));
         }
     }
 }

--- a/test/IbanNet.FluentValidation.Tests/IbanNet.FluentValidation.Tests.csproj
+++ b/test/IbanNet.FluentValidation.Tests/IbanNet.FluentValidation.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
 
     <IsTestProject>true</IsTestProject>
 
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="9.3.0" />
+    <PackageReference Include="FluentValidation" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>
@@ -17,7 +17,6 @@
     <ProjectReference Include="..\..\src\IbanNet.FluentValidation\IbanNet.FluentValidation.csproj" AdditionalProperties="TargetFramework=net5.0" Condition="'$(TargetFramework)'=='net5.0'" />
     <ProjectReference Include="..\..\src\IbanNet.FluentValidation\IbanNet.FluentValidation.csproj" AdditionalProperties="TargetFramework=netstandard2.1" Condition="'$(TargetFramework)'=='netcoreapp3.1'" />
     <ProjectReference Include="..\..\src\IbanNet.FluentValidation\IbanNet.FluentValidation.csproj" AdditionalProperties="TargetFramework=netstandard2.0" Condition="'$(TargetFramework)'=='netcoreapp2.1'" />
-    <ProjectReference Include="..\..\src\IbanNet.FluentValidation\IbanNet.FluentValidation.csproj" AdditionalProperties="TargetFramework=net461" Condition="'$(TargetFramework)'=='net461'" />
     <ProjectReference Include="..\TestHelpers\TestHelpers.csproj" />
   </ItemGroup>
 

--- a/test/IbanNet.FluentValidation.Tests/IntegrationTests.cs
+++ b/test/IbanNet.FluentValidation.Tests/IntegrationTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using FluentValidation;
@@ -32,8 +31,7 @@ namespace IbanNet.FluentValidation
             var expectedValidationFailure = new ValidationFailure(nameof(_testModel.BankAccountNumber), $"'{expectedFormattedPropertyName}' is not a valid IBAN.")
             {
                 AttemptedValue = attemptedIbanValue,
-                ErrorCode = nameof(FluentIbanValidator),
-                FormattedMessageArguments = Array.Empty<object>(),
+                ErrorCode = "FluentIbanValidator",
                 FormattedMessagePlaceholderValues = new Dictionary<string, object>
                 {
                     { "PropertyName", expectedFormattedPropertyName },

--- a/test/IbanNet.FluentValidation.Tests/RuleBuilderExtensionsTests.cs
+++ b/test/IbanNet.FluentValidation.Tests/RuleBuilderExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using FluentAssertions;
 using FluentValidation;
+using FluentValidation.Validators;
 using Moq;
 using Xunit;
 
@@ -52,7 +53,7 @@ namespace IbanNet.FluentValidation
             ruleBuilderMock.Object.Iban(ibanValidator);
 
             // Assert
-            ruleBuilderMock.Verify(m => m.SetValidator(It.IsAny<FluentIbanValidator>()), Times.Once);
+            ruleBuilderMock.Verify(m => m.SetValidator(It.Is<IPropertyValidator<object, string>>(x => x.GetType() == typeof(FluentIbanValidator<object>))), Times.Once);
         }
     }
 }


### PR DESCRIPTION
Closes #30 

Breaking change:
- Updates FluentValidation dependencies to v10.x
- `PropertyValidator` is deprecated