### PR TITLE
fix: adds branch information to FR

### DIFF
--- a/src/IbanNet.CodeGen/Swift/Patches/FranceBranchPatch.cs
+++ b/src/IbanNet.CodeGen/Swift/Patches/FranceBranchPatch.cs
@@ -1,0 +1,32 @@
+﻿namespace IbanNet.CodeGen.Swift.Patches;
+
+/// <summary>
+/// See https://github.com/skwasjer/IbanNet/issues/77
+/// </summary>
+internal class FranceBranchPatch : RecordPatcher
+{
+    protected override SwiftCsvRecord Apply(SwiftCsvRecord record)
+    {
+        if (record is { CountryCode: "FR" })
+        {
+            int branchStartPos = record.Bank.Position!.Value.EndPos + 1;
+            return record with
+            {
+                Branch = record.Branch with
+                {
+                    Pattern = "5!n",
+                    Position = new Position
+                    {
+                        StartPos = branchStartPos,
+                        EndPos = branchStartPos + 5
+                    },
+                    Example = "01005"
+                }
+            };
+        }
+        else
+        {
+            return record;
+        }
+    }
+}

--- a/src/IbanNet.CodeGen/Swift/Patches/RecordPatcher.cs
+++ b/src/IbanNet.CodeGen/Swift/Patches/RecordPatcher.cs
@@ -1,0 +1,24 @@
+﻿namespace IbanNet.CodeGen.Swift.Patches;
+
+public abstract class RecordPatcher
+{
+    private static IList<RecordPatcher>? _patches;
+
+    protected abstract SwiftCsvRecord Apply(SwiftCsvRecord record);
+
+    public static SwiftCsvRecord ApplyAll(SwiftCsvRecord record)
+    {
+        return GetPatches().Aggregate(record, (current, patch) => patch.Apply(current));
+    }
+
+    private static IEnumerable<RecordPatcher> GetPatches()
+    {
+        return _patches ??=
+            typeof(RecordPatcher).Assembly
+                .GetTypes()
+                .Where(t => !t.IsAbstract && typeof(RecordPatcher).IsAssignableFrom(t))
+                .Select(Activator.CreateInstance)
+                .Cast<RecordPatcher>()
+                .ToList();
+    }
+}

--- a/src/IbanNet.CodeGen/Swift/SwiftCsvRecord.cs
+++ b/src/IbanNet.CodeGen/Swift/SwiftCsvRecord.cs
@@ -4,7 +4,7 @@ using IbanNet.CodeGen.Swift.Converters;
 
 namespace IbanNet.CodeGen.Swift;
 
-public sealed class SwiftCsvRecord
+public sealed record SwiftCsvRecord
 {
     private string _countryCode = default!;
 
@@ -73,7 +73,7 @@ public record struct Position
     public int EndPos { get; set; }
 }
 
-public class IbanCsvData
+public record IbanCsvData
 {
     [Name("IBAN structure")]
     public string Pattern { get; set; } = default!;
@@ -88,7 +88,7 @@ public class IbanCsvData
     public string? PrintFormatExample { get; set; }
 }
 
-public abstract class PatternCsvData
+public abstract record PatternCsvData
 {
     public virtual string? Pattern { get; set; }
 
@@ -98,7 +98,7 @@ public abstract class PatternCsvData
     public virtual string? Example { get; set; }
 }
 
-public class BbanCsvData : PatternCsvData
+public record BbanCsvData : PatternCsvData
 {
     [Name("BBAN structure")]
     public override string? Pattern { get; set; }
@@ -117,7 +117,7 @@ public class BbanCsvData : PatternCsvData
     public override string? Example { get; set; }
 }
 
-public class BankCsvData : PatternCsvData
+public record BankCsvData : PatternCsvData
 {
     [Name("Bank identifier pattern")]
     public override string? Pattern { get; set; }
@@ -129,7 +129,7 @@ public class BankCsvData : PatternCsvData
     public override string? Example { get; set; }
 }
 
-public class BranchCsvData : PatternCsvData
+public record BranchCsvData : PatternCsvData
 {
     [Name("Branch identifier pattern")]
     public override string? Pattern { get; set; }
@@ -141,7 +141,7 @@ public class BranchCsvData : PatternCsvData
     public override string? Example { get; set; }
 }
 
-public class SepaCsvData
+public record SepaCsvData
 {
     [Name("SEPA country")]
     [BooleanTrueValues("Yes")]

--- a/src/IbanNet/Registry/Swift/SwiftRegistryProvider.cs
+++ b/src/IbanNet/Registry/Swift/SwiftRegistryProvider.cs
@@ -941,6 +941,10 @@ namespace IbanNet.Registry.Swift
                 {
                     Example = "20041"
                 },
+                Branch = new BranchStructure(new SwiftPattern("5!n"), 9)
+                {
+                    Example = "01005"
+                },
                 Sepa = new SepaInfo
                 {
                     IsMember = true,

--- a/src/IbanNet/Registry/Swift/SwiftRegistryProvider.tt
+++ b/src/IbanNet/Registry/Swift/SwiftRegistryProvider.tt
@@ -64,7 +64,7 @@ namespace IbanNet.Registry.Swift
     var csv = new SwiftCsvReader(new StreamReader(registryPath, Encoding.GetEncoding(1252)));
     var records = csv.GetRecords<SwiftCsvRecord>();
 
-    foreach (var record in records)
+    foreach (var record in records.Select(IbanNet.CodeGen.Swift.Patches.RecordPatcher.ApplyAll))
     {
         int bbanOffset = record.Iban.Length - record.Bban.Length;
         if (Boycott(record.CountryCode)) continue;

--- a/test/IbanNet.Tests/Issues/77_FranceIsMissingBranch.cs
+++ b/test/IbanNet.Tests/Issues/77_FranceIsMissingBranch.cs
@@ -1,0 +1,24 @@
+﻿using IbanNet.Registry;
+
+namespace IbanNet.Issues;
+
+/// <summary>
+/// Issue #77
+/// </summary>
+public class _77_FranceIsMissingBranch
+{
+    [Fact]
+    public void When_extracting_france_branch_code_it_should_return_expected()
+    {
+        var ibanParser = new IbanParser(IbanRegistry.Default);
+
+        // Act
+        bool isValid = ibanParser.TryParse("FR7630001007941234567890185", out Iban iban);
+
+        // Assert
+        isValid.Should().BeTrue();
+        iban!.BranchIdentifier.Should()
+            .NotBeNull()
+            .And.Be("00794");
+    }
+}


### PR DESCRIPTION
Addresses #77 at the code generation level. 

Adds an abstract way of adding specific patches before actually generating the registry provider. New (future) patches can easily be added by implementing `RecordPatcher`, which will then be applied automatically when regenerating the provider.
This way we do not have to expose internal types or change the immutable aspect of the registry (even though this can and should still be considered as a separate change).
