### PR TITLE
feat(validator): move normalization to parser, such that validator is always validating strictly

### DIFF
--- a/src/IbanNet.DataAnnotations/IbanNet.DataAnnotations.csproj
+++ b/src/IbanNet.DataAnnotations/IbanNet.DataAnnotations.csproj
@@ -13,6 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\IbanNet\Extensions\CharExtensions.cs" Link="Internal\Extensions\CharExtensions.cs" />
+    <Compile Include="..\IbanNet\Internal\InputNormalization.cs" Link="Internal\InputNormalization.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 

--- a/src/IbanNet.FluentValidation/IbanNet.FluentValidation.csproj
+++ b/src/IbanNet.FluentValidation/IbanNet.FluentValidation.csproj
@@ -13,6 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\IbanNet\Extensions\CharExtensions.cs" Link="Internal\Extensions\CharExtensions.cs" />
+    <Compile Include="..\IbanNet\Internal\InputNormalization.cs" Link="Internal\InputNormalization.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 

--- a/src/IbanNet.FluentValidation/RuleBuilderExtensions.cs
+++ b/src/IbanNet.FluentValidation/RuleBuilderExtensions.cs
@@ -14,18 +14,26 @@ namespace IbanNet.FluentValidation
         /// <typeparam name="T">Type of object being validated</typeparam>
         /// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
         /// <param name="ibanValidator">The <see cref="IIbanValidator" /> instance to use for validation.</param>
+        /// <param name="strict">
+        /// When true, the input must strictly match the IBAN format rules.
+        /// When false, whitespace is ignored and strict character casing enforcement is disabled (meaning, the user can input in lower and uppercase). This mode is a bit more forgiving when dealing with user-input. However it does require after successful validation, that you parse the user input with <see cref="IIbanParser" /> to normalize/sanitize the input and to be able to format the IBAN in correct electronic format.
+        ///
+        /// <para>Default is <see langword="true" />. (this may change in future major release)</para>
+        /// </param>
         /// <returns></returns>
         public static IRuleBuilderOptions<T, string> Iban<T>
         (
             this IRuleBuilder<T, string> ruleBuilder,
-            IIbanValidator ibanValidator)
+            IIbanValidator ibanValidator,
+            bool strict = true
+        )
         {
             if (ruleBuilder is null)
             {
                 throw new ArgumentNullException(nameof(ruleBuilder));
             }
 
-            return ruleBuilder.SetValidator(new FluentIbanValidator<T>(ibanValidator));
+            return ruleBuilder.SetValidator(new FluentIbanValidator<T>(ibanValidator) { Strict = strict });
         }
     }
 }

--- a/src/IbanNet/IbanParser.cs
+++ b/src/IbanNet/IbanParser.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using IbanNet.Internal;
 using IbanNet.Registry;
 
 namespace IbanNet
@@ -77,9 +78,11 @@ namespace IbanNet
             iban = null;
             exceptionThrown = null;
 
+            string? normalizedValue = InputNormalization.NormalizeOrNull(value);
+
             try
             {
-                validationResult = _ibanValidator.Validate(value);
+                validationResult = _ibanValidator.Validate(normalizedValue);
             }
             catch (Exception ex)
             {
@@ -93,7 +96,7 @@ namespace IbanNet
                 return false;
             }
 
-            iban = new Iban(validationResult.AttemptedValue!, validationResult.Country!);
+            iban = new Iban(normalizedValue!, validationResult.Country!, true);
             return true;
         }
     }

--- a/src/IbanNet/IbanValidator.cs
+++ b/src/IbanNet/IbanValidator.cs
@@ -77,9 +77,7 @@ namespace IbanNet
         /// <returns>a validation result, indicating if the IBAN is valid or not</returns>
         public ValidationResult Validate(string? iban)
         {
-            string? normalizedIban = Iban.NormalizeOrNull(iban);
-
-            var context = new ValidationRuleContext(normalizedIban ?? string.Empty);
+            var context = new ValidationRuleContext(iban ?? string.Empty);
             ErrorResult? error = null;
 
             foreach (IIbanValidationRule rule in _rules)
@@ -101,7 +99,7 @@ namespace IbanNet
 
             return new ValidationResult
             {
-                AttemptedValue = normalizedIban,
+                AttemptedValue = iban,
                 Country = context.Country,
                 Error = error
             };

--- a/src/IbanNet/Internal/InputNormalization.cs
+++ b/src/IbanNet/Internal/InputNormalization.cs
@@ -1,0 +1,57 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using IbanNet.Extensions;
+
+namespace IbanNet.Internal;
+
+internal static class InputNormalization
+{
+    /// <summary>
+    /// Normalizes an IBAN by removing whitespace, removing non-alphanumerics and upper casing each character.
+    /// </summary>
+    /// <param name="value">The input value to normalize.</param>
+    /// <returns>The normalized IBAN.</returns>
+    internal static string? NormalizeOrNull([NotNullIfNotNull("value")] string? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        int length = value.Length;
+#if USE_SPANS
+        // Use stack but clamp to avoid excessive stackalloc buffer.
+        const int stackallocMaxSize = Iban.MaxLength + 6;
+        Span<char> buffer = length <= stackallocMaxSize
+            ? stackalloc char[length]
+            : new char[length];
+#else
+            char[] buffer = new char[length];
+#endif
+        int pos = 0;
+        // ReSharper disable once ForCanBeConvertedToForeach - justification : performance
+        for (int i = 0; i < length; i++)
+        {
+            char ch = value[i];
+            if (ch.IsWhitespace())
+            {
+                continue;
+            }
+
+            if (ch.IsAsciiLetter())
+            {
+                // Inline upper case.
+                buffer[pos++] = (char)(ch & ~' ');
+            }
+            else
+            {
+                buffer[pos++] = ch;
+            }
+        }
+
+#if USE_SPANS
+        return new string(buffer[..pos]);
+#else
+            return new string(buffer, 0, pos);
+#endif
+    }
+}

--- a/test/IbanNet.DataAnnotations.Tests/AspNetIntegrationTest.cs
+++ b/test/IbanNet.DataAnnotations.Tests/AspNetIntegrationTest.cs
@@ -27,7 +27,7 @@ namespace IbanNet.DataAnnotations
             using HttpClient client = _fixture.TestServer.CreateClient();
 
             // Act
-            HttpResponseMessage response = await client.SendAsync(CreateSaveRequest(validIban));
+            HttpResponseMessage response = await client.SendAsync(CreateSaveRequest(validIban, false));
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -35,13 +35,13 @@ namespace IbanNet.DataAnnotations
         }
 
         [Fact]
-        public async Task Given_invalid_iban_when_posting_with_attribute_validation_it_should_validate()
+        public async Task Given_invalid_iban_when_posting_with_attribute_validation_it_should_not_validate()
         {
             const string invalidIban = "invalid-iban";
             using HttpClient client = _fixture.TestServer.CreateClient();
 
             // Act
-            HttpResponseMessage response = await client.SendAsync(CreateSaveRequest(invalidIban));
+            HttpResponseMessage response = await client.SendAsync(CreateSaveRequest(invalidIban, false));
 
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -58,9 +58,9 @@ namespace IbanNet.DataAnnotations
                 .Contain("The field 'BankAccountNumber' is not a valid IBAN.");
         }
 
-        private static HttpRequestMessage CreateSaveRequest(string iban)
+        private static HttpRequestMessage CreateSaveRequest(string iban, bool strict)
         {
-            return new(HttpMethod.Post, "test/save")
+            return new(HttpMethod.Post, "test/save" + (strict ? "-strict" : ""))
             {
                 Headers =
                 {

--- a/test/IbanNet.DataAnnotations.Tests/AspNetWebHostFixture.cs
+++ b/test/IbanNet.DataAnnotations.Tests/AspNetWebHostFixture.cs
@@ -1,9 +1,8 @@
 ﻿#if ASPNET_INTEGRATION_TESTS
+using IbanNet.DependencyInjection.ServiceProvider;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json;
 
 namespace IbanNet.DataAnnotations
 {
@@ -14,7 +13,7 @@ namespace IbanNet.DataAnnotations
 #pragma warning restore CA1822 // Mark members as static
         {
             services
-                .AddSingleton<IIbanValidator, IbanValidator>()
+                .AddIbanNet()
                 .AddMvc()
                 .AddControllersAsServices();
         }

--- a/test/IbanNet.DataAnnotations.Tests/IbanAttributeTests.cs
+++ b/test/IbanNet.DataAnnotations.Tests/IbanAttributeTests.cs
@@ -13,14 +13,13 @@ namespace IbanNet.DataAnnotations
 
         private ValidationContext _validationContext;
 
-        public IbanAttributeTests()
+        protected IbanAttributeTests()
         {
             _ibanValidatorStub = new IbanValidatorStub();
             _serviceProviderMock = new Mock<IServiceProvider>();
             _serviceProviderMock
                 .Setup(m => m.GetService(typeof(IIbanValidator)))
-                .Returns(_ibanValidatorStub)
-                .Verifiable();
+                .Returns(_ibanValidatorStub);
 
             _validationContext = new ValidationContext(new object(), _serviceProviderMock.Object, null);
 
@@ -36,7 +35,7 @@ namespace IbanNet.DataAnnotations
                 _sut.GetValidationResult(null, _validationContext);
 
                 // Assert
-                _ibanValidatorStub.Verify(m => m.Validate(TestValues.ValidIban), Times.Never);
+                _ibanValidatorStub.VerifyNoOtherCalls();
             }
 
             [Fact]
@@ -80,6 +79,7 @@ namespace IbanNet.DataAnnotations
 
                 // Assert
                 _ibanValidatorStub.Verify(m => m.Validate(TestValues.ValidIban), Times.Once);
+                _ibanValidatorStub.VerifyNoOtherCalls();
             }
 
             [Fact]
@@ -89,7 +89,8 @@ namespace IbanNet.DataAnnotations
                 _sut.GetValidationResult(TestValues.ValidIban, _validationContext);
 
                 // Assert
-                _serviceProviderMock.Verify();
+                _serviceProviderMock.Verify(m => m.GetService(typeof(IIbanValidator)));
+                _serviceProviderMock.VerifyNoOtherCalls();
             }
 
             [Fact]
@@ -123,6 +124,7 @@ namespace IbanNet.DataAnnotations
 
                 // Assert
                 _ibanValidatorStub.Verify(m => m.Validate(TestValues.InvalidIban), Times.Once);
+                _ibanValidatorStub.VerifyNoOtherCalls();
             }
 
             [Fact]
@@ -154,7 +156,8 @@ namespace IbanNet.DataAnnotations
                 _sut.GetValidationResult(TestValues.InvalidIban, _validationContext);
 
                 // Assert
-                _serviceProviderMock.Verify();
+                _serviceProviderMock.Verify(m => m.GetService(typeof(IIbanValidator)));
+                _serviceProviderMock.VerifyNoOtherCalls();
             }
 
             [Fact]
@@ -212,7 +215,7 @@ namespace IbanNet.DataAnnotations
                 act.Should().Throw<NotImplementedException>();
 
                 _serviceProviderMock.Verify(m => m.GetService(It.IsAny<Type>()), Times.Never);
-                _ibanValidatorStub.Verify(m => m.Validate(TestValues.InvalidIban), Times.Never);
+                _ibanValidatorStub.VerifyNoOtherCalls();
             }
         }
 
@@ -235,7 +238,7 @@ namespace IbanNet.DataAnnotations
                     .Throw<InvalidOperationException>()
                     .WithMessage("Failed to get an instance of *");
                 _serviceProviderMock.Verify();
-                _ibanValidatorStub.Verify(m => m.Validate(TestValues.ValidIban), Times.Never);
+                _ibanValidatorStub.VerifyNoOtherCalls();
             }
         }
 
@@ -254,7 +257,7 @@ namespace IbanNet.DataAnnotations
                 act.Should()
                     .Throw<InvalidOperationException>()
                     .WithMessage("Failed to get an instance of *");
-                _ibanValidatorStub.Verify(m => m.Validate(TestValues.ValidIban), Times.Never);
+                _ibanValidatorStub.VerifyNoOtherCalls();
             }
         }
 

--- a/test/IbanNet.DataAnnotations.Tests/IbanNet.DataAnnotations.Tests.csproj
+++ b/test/IbanNet.DataAnnotations.Tests/IbanNet.DataAnnotations.Tests.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=netstandard1.6" Condition="'$(TargetFramework)'=='net48'" />
     <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=net472" Condition="'$(TargetFramework)'=='net472'" />
     <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=net462" Condition="'$(TargetFramework)'=='net462'" />
+    <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.ServiceProvider\IbanNet.DependencyInjection.ServiceProvider.csproj" />
     <ProjectReference Include="..\TestHelpers\TestHelpers.csproj" />
   </ItemGroup>
 

--- a/test/IbanNet.DataAnnotations.Tests/InputModel.cs
+++ b/test/IbanNet.DataAnnotations.Tests/InputModel.cs
@@ -5,7 +5,7 @@ namespace IbanNet.DataAnnotations
     public class InputModel
     {
         [Required]
-        [Iban]
+        [Iban(Strict = false)]
         public string BankAccountNumber { get; set; }
     }
 }

--- a/test/IbanNet.DataAnnotations.Tests/IntegrationTests.cs
+++ b/test/IbanNet.DataAnnotations.Tests/IntegrationTests.cs
@@ -1,0 +1,75 @@
+﻿#if NETCOREAPP
+using System.ComponentModel.DataAnnotations;
+using IbanNet.DependencyInjection.ServiceProvider;
+using IbanNet.Validation.Results;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace IbanNet.DataAnnotations
+{
+    public class IntegrationTests
+    {
+        [Theory]
+        [MemberData(nameof(InvalidTestCases))]
+        public void Given_a_model_with_invalid_iban_when_validating_should_contain_validation_errors
+        (
+            string attemptedIbanValue,
+            bool strict,
+            ErrorResult expectedError
+        )
+        {
+            using ServiceProvider services = new ServiceCollection()
+                .AddIbanNet()
+                .BuildServiceProvider();
+            var ctx = new ValidationContext(new object(), services, new Dictionary<object, object>());
+
+            // Act
+            var sut = new IbanAttribute { Strict = strict };
+            System.ComponentModel.DataAnnotations.ValidationResult actual = sut.GetValidationResult(attemptedIbanValue, ctx);
+
+            // Assert
+            actual.Should().NotBe(System.ComponentModel.DataAnnotations.ValidationResult.Success, "because one validation error should have occurred");
+            ctx.Items.Should()
+                .ContainKey("Error")
+                .WhoseValue.Should()
+                .BeEquivalentTo(expectedError);
+        }
+
+        public static IEnumerable<object[]> InvalidTestCases()
+        {
+            yield return new object[] { "nl91ABNA0417164300", true, new InvalidStructureResult() };
+            yield return new object[] { "PL611090101400000712198128741", true, new InvalidLengthResult() };
+            yield return new object[] { "PL611090101400000712198128741", false, new InvalidLengthResult() };
+            yield return new object[] { "PL61 1090 10140000071219812874", true, new IllegalCharactersResult() };
+            yield return new object[] { "AE07033123456789012345", true, new InvalidLengthResult() };
+            yield return new object[] { "AE07033123456789012345", false, new InvalidLengthResult() };
+            yield return new object[] { "AE07 0331 234567890123456", true, new IllegalCharactersResult() };
+            yield return new object[] { "MT84malt011000012345mtlcast001S", true, new InvalidStructureResult() };
+        }
+
+        [Theory]
+        [InlineData("nl91ABNA0417164300", false)]
+        [InlineData("PL61109010140000071219812874", true)]
+        [InlineData("PL61109010140000071219812874", false)]
+        [InlineData("PL61 1090 10140000071219812874", false)]
+        [InlineData("AE070331234567890123456", true)]
+        [InlineData("AE070331234567890123456", false)]
+        [InlineData("AE07 0331 234567890123456", false)]
+        [InlineData("MT84MALT011000012345mtlcast001S", true)]
+        [InlineData("MT84malt011000012345mtlcast001S", false)]
+        public void Given_a_model_with_iban_when_validating_should_not_contain_validation_errors(string attemptedIbanValue, bool strict)
+        {
+            using ServiceProvider services = new ServiceCollection()
+                .AddIbanNet()
+                .BuildServiceProvider();
+            var ctx = new ValidationContext(new object(), services, new Dictionary<object, object>());
+
+            // Act
+            var sut = new IbanAttribute { Strict = strict };
+            System.ComponentModel.DataAnnotations.ValidationResult actual = sut.GetValidationResult(attemptedIbanValue, ctx);
+
+            // Assert
+            actual.Should().Be(System.ComponentModel.DataAnnotations.ValidationResult.Success);
+        }
+    }
+}
+#endif

--- a/test/IbanNet.DataAnnotations.Tests/StrictInputModel.cs
+++ b/test/IbanNet.DataAnnotations.Tests/StrictInputModel.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace IbanNet.DataAnnotations;
+
+public class StrictInputModel
+{
+    [Required]
+    [Iban(Strict = true)]
+    public string BankAccountNumber { get; set; }
+}

--- a/test/IbanNet.DataAnnotations.Tests/TestController.cs
+++ b/test/IbanNet.DataAnnotations.Tests/TestController.cs
@@ -12,6 +12,12 @@ namespace IbanNet.DataAnnotations
         {
             return Ok(iban.BankAccountNumber);
         }
+
+        [HttpPost("save-strict")]
+        public IActionResult Save(StrictInputModel iban)
+        {
+            return Ok(iban.BankAccountNumber);
+        }
     }
 }
 #endif

--- a/test/IbanNet.Tests/IbanParserTests.cs
+++ b/test/IbanNet.Tests/IbanParserTests.cs
@@ -126,6 +126,27 @@ namespace IbanNet
                 ex.Message.Should().Be("The IBAN contains illegal characters.");
             }
 
+            [Theory]
+            [InlineData("NL91 ABNA 0417 1643 00")]
+            [InlineData("NL91\tABNA\t0417\t1643\t00")]
+            [InlineData(" NL91 ABNA041 716 4300 ")]
+            [InlineData("nl91 ABNA041716\t4300")]
+            public void Given_that_iban_contains_whitespace_or_lowercase_when_parsing_it_should_succeed(string iban)
+            {
+                const string expectedNormalizedIban = "NL91ABNA0417164300";
+                _ibanValidatorStub
+                    .Setup(m => m.Validate(expectedNormalizedIban))
+                    .Returns(new ValidationResult { AttemptedValue = iban, Country = new IbanCountry("NL") })
+                    .Verifiable();
+
+                // Act
+                Iban actual = _sut.Parse(iban);
+
+                // Assert
+                actual.ToString().Should().Be(expectedNormalizedIban);
+                _ibanValidatorStub.Verify();
+            }
+
             [Fact]
             public void With_valid_value_should_return_iban()
             {

--- a/test/IbanNet.Tests/IbanTests.cs
+++ b/test/IbanNet.Tests/IbanTests.cs
@@ -275,41 +275,6 @@ namespace IbanNet
             }
         }
 
-        public class When_normalizing
-        {
-            [Theory]
-            [InlineData("no-whitespace", "NO-WHITESPACE")]
-            [InlineData(" \tin-\nstr ing\r", "IN-STRING")]
-            [InlineData("(&*!S #%t", "(&*!S#%T")]
-            [InlineData("", "")]
-            [InlineData(null, null)]
-            public void Given_string_when_normalizing_it_should_return_expected_value(string input, string expected)
-            {
-                // Act
-                string actual = Iban.NormalizeOrNull(input);
-
-                // Assert
-                actual.Should().Be(expected);
-            }
-
-#if USE_SPANS
-            [Fact]
-            public void Given_that_string_exceeds_max_stackalloc_length_when_normalizing_it_should_return_expected_value()
-            {
-                string spaces = new(' ', 50);
-                string input = spaces + " \tin-\nstr ing\r" + spaces;
-                input.Length.Should().BeGreaterThan(Iban.MaxLength * 2);
-                const string expected = "IN-STRING";
-
-                // Act
-                string actual = Iban.NormalizeOrNull(input);
-
-                // Assert
-                actual.Should().Be(expected);
-            }
-#endif
-        }
-
         public class When_getting_properties : IbanTests
         {
             [Fact]

--- a/test/IbanNet.Tests/IbanValidatorIntegrationTests.cs
+++ b/test/IbanNet.Tests/IbanValidatorIntegrationTests.cs
@@ -6,11 +6,11 @@ namespace IbanNet
     {
         private readonly IbanValidator _sut = new();
 
-        [Fact]
-        public void When_validating_iban_with_invalid_structure_should_not_validate()
+        [Theory]
+        [InlineData("nl91ABNA0417164300")] // Lower case country code.
+        [InlineData("NL91ABNA041716430A")] // Last character should be digit.
+        public void When_validating_iban_with_invalid_structure_should_not_validate(string ibanWithInvalidStructure)
         {
-            const string ibanWithInvalidStructure = "NL91ABNA041716430A"; // Last character should be digit.
-
             // Act
             ValidationResult actual = _sut.Validate(ibanWithInvalidStructure);
 
@@ -34,7 +34,7 @@ namespace IbanNet
             // Assert
             actual.Should().BeEquivalentTo(new ValidationResult
             {
-                AttemptedValue = ibanWithLowercase.ToUpperInvariant(),
+                AttemptedValue = ibanWithLowercase,
                 Country = _sut.SupportedCountries[ibanWithLowercase.Substring(0, 2)]
             });
         }
@@ -161,7 +161,7 @@ namespace IbanNet
         [InlineData("NL91 ABNA 0417 1643 00")]
         [InlineData("NL91\tABNA\t0417\t1643\t00")]
         [InlineData(" NL91 ABNA041 716 4300 ")]
-        public void When_iban_contains_whitespace_should_validate(string ibanWithWhitespace)
+        public void Given_that_iban_contains_whitespace_when_validating_it_should_fail(string ibanWithWhitespace)
         {
             // Act
             ValidationResult actual = _sut.Validate(ibanWithWhitespace);
@@ -169,8 +169,8 @@ namespace IbanNet
             // Assert
             actual.Should().BeEquivalentTo(new ValidationResult
             {
-                AttemptedValue = Iban.NormalizeOrNull(ibanWithWhitespace),
-                Country = _sut.SupportedCountries["NL"]
+                AttemptedValue = ibanWithWhitespace,
+                Error = new IllegalCharactersResult()
             });
         }
 

--- a/test/IbanNet.Tests/Internal/InputNormalizationTests.cs
+++ b/test/IbanNet.Tests/Internal/InputNormalizationTests.cs
@@ -1,0 +1,36 @@
+﻿namespace IbanNet.Internal;
+
+public class InputNormalizationTests
+{
+    [Theory]
+    [InlineData("no-whitespace", "NO-WHITESPACE")]
+    [InlineData(" \tin-\nstr ing\r", "IN-STRING")]
+    [InlineData("(&*!S #%t", "(&*!S#%T")]
+    [InlineData("", "")]
+    [InlineData(null, null)]
+    public void Given_string_when_normalizing_it_should_return_expected_value(string input, string expected)
+    {
+        // Act
+        string actual = InputNormalization.NormalizeOrNull(input);
+
+        // Assert
+        actual.Should().Be(expected);
+    }
+
+#if USE_SPANS
+    [Fact]
+    public void Given_that_string_exceeds_max_stackalloc_length_when_normalizing_it_should_return_expected_value()
+    {
+        string spaces = new(' ', 50);
+        string input = spaces + " \tin-\nstr ing\r" + spaces;
+        input.Length.Should().BeGreaterThan(Iban.MaxLength * 2);
+        const string expected = "IN-STRING";
+
+        // Act
+        string actual = InputNormalization.NormalizeOrNull(input);
+
+        // Assert
+        actual.Should().Be(expected);
+    }
+#endif
+}


### PR DESCRIPTION
Move normalization to parser, such that validator is always validating strict. 

Add `Strict`-property (default true) to `IbanAttribute` and `FluentIbanValidator<T>` and its associated `Iban` rule extension. When Strict=true, the input must strictly match the IBAN format rules. When Strict=false, whitespace is ignored and strict character casing enforcement is disabled (meaning, the user can input in lower and uppercase). 

This mode is a bit more forgiving when dealing with user-input. However it does require after successful validation, that you parse the user input with `IIbanParser` to normalize/sanitize the input and to be able to format the IBAN in correct electronic format.

Strict defaults to true.

See #93

Examples:

```csharp
// DataAnnotations
public class InputModel
{
    [Iban(Strict = false)]
    [Required]
    public string BackAccountNumber { get; set; }
}

// FluentValidation
public class InputModelValidator : AbstractValidator<InputModel>
{
    public InputModelValidator(IIbanValidator ibanValidator)
    {
        RuleFor(x => x.BankAccountNumber).NotNull().Iban(ibanValidator, strict: false);
    }
}
```

With validator/parser directly:
```csharp
static void Main()
{
    string inputStr = "NL91 ABNA 0417 1643 00";

    var validator = new IbanValidator();
    Console.Write(validator.Validate(inputStr).IsValid)   // false

    var parser = new IbanParser(IbanRegistry.Default);
    Console.Write(parser.TryParse(inputStr, out _));      // true
}
```
