### PR TITLE
Refactor/update CI to build with latest

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,17 +38,13 @@ jobs:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
           6.0.x
           5.0.x
           3.1.x
-          2.1.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -9,25 +9,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        framework-version: [net6.0, net5.0, netcoreapp3.1]
+        framework-version: [net7.0, net6.0, net5.0, netcoreapp3.1]
 
     steps:
-      - uses: actions/checkout@master
-
-      - name: Setup .NET 6.0
-        uses: actions/setup-dotnet@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
-
-      - name: Setup .NET 5.0
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 5.0.x
-
-      - name: Setup .NET Core 3.1
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 3.1.x
+          dotnet-version: |
+            6.0.x
+            5.0.x
+            3.1.x
 
       - name: Tests
         run: dotnet test -c Release -f ${{ matrix.framework-version }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -4,12 +4,11 @@ on: [push, pull_request]
 
 jobs:
   dotnet:
-    name: ${{ matrix.framework-version }} on ${{ matrix.os }}
+    name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        framework-version: [net7.0, net6.0, net5.0, netcoreapp3.1]
 
     steps:
       - uses: actions/checkout@v3
@@ -20,5 +19,4 @@ jobs:
             5.0.x
             3.1.x
 
-      - name: Tests
-        run: dotnet test -c Release -f ${{ matrix.framework-version }}
+      - run: dotnet test -c Release

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -15,17 +15,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
             6.0.x
             5.0.x
             3.1.x
-            2.1.x
 
       - name: Install Sonar scanner
         run: dotnet tool install --global dotnet-sonarscanner

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>$(NoWarn);IDE0079;S1135</NoWarn>
+    <NoWarn Condition="'$(Configuration)'=='Release'">$(NoWarn);NETSDK1138</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
- Update to v3 actions
- Remove .NET Core 2.1 SDK install
- `dotnet test` also .NET 4.x (works now since Mono has been included in runner images)
- Suppress .NET EOL warnings