### PR TITLE
chore(deps): Set test projects PackageReferences to wildcard version

### DIFF
--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -4,7 +4,6 @@
     <IsPackable>false</IsPackable>
 
     <DefineConstants Condition="'$(TargetFramework)'=='net48'">$(DefineConstants);NETSTD_LEGACY</DefineConstants>
-    <MsTestSdkVersion>17.6.2</MsTestSdkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,14 +13,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="FluentAssertions" Version="*" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MsTestSdkVersion)" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="$(MsTestSdkVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="*" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/IbanNet.Tests/IbanNet.Tests.csproj
+++ b/test/IbanNet.Tests/IbanNet.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="*" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net462'">


### PR DESCRIPTION
_Created as PR as it might be easier to discuss after prof of concept implementation. (Ok I admit, I was eager to get started and began a PR before reading project guidelines)_

Set common dependabot updated packages in test projects to wildcard (to reduce dependabot noise)

Internal only used PackageReferences in test projects, such as Microsoft.NET.Test.Sdk, Microsoft.TestPlatform.ObjectModel, FluentAssertions and also Newtonsoft.Json in Test project do not affect resulting package, so having these packages being non immutable should not pose any issues.

There is possible issues with builds/tests not being immutable, but they should be theoretical at best. Reduced maintenance and noise from dependabot should be worth it.

_Happy to update/fix for "Conventional Commits" but might need some guidance, would `chore!:` be correct here?_