### PR TITLE
chore(deps): replace Moq with NSubstitute

### DIFF
--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -8,13 +8,17 @@
 
   <ItemGroup>
     <Using Include="FluentAssertions" />
-    <Using Include="Moq" />
+    <Using Include="NSubstitute" />
     <Using Include="Xunit" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="*" />
-    <PackageReference Include="Moq" Version="[4.18.4]" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.2" />
   </ItemGroup>
 

--- a/test/IbanNet.DependencyInjection.Autofac.Tests/Specs/ShouldResolveCustomService.cs
+++ b/test/IbanNet.DependencyInjection.Autofac.Tests/Specs/ShouldResolveCustomService.cs
@@ -19,10 +19,10 @@ public class ShouldResolveCustomService : TestHelpers.Specs.ShouldResolveCustomS
 
         protected override void Configure(ContainerBuilder containerBuilder, Action<IIbanNetOptionsBuilder> configurer)
         {
-            containerBuilder.RegisterInstance(Mock.Of<IIbanRegistry>());
-            containerBuilder.RegisterInstance(Mock.Of<IIbanParser>());
-            containerBuilder.RegisterInstance(Mock.Of<IIbanGenerator>());
-            containerBuilder.RegisterInstance(Mock.Of<IIbanValidator>());
+            containerBuilder.RegisterInstance(Substitute.For<IIbanRegistry>());
+            containerBuilder.RegisterInstance(Substitute.For<IIbanParser>());
+            containerBuilder.RegisterInstance(Substitute.For<IIbanGenerator>());
+            containerBuilder.RegisterInstance(Substitute.For<IIbanValidator>());
 
             base.Configure(containerBuilder, configurer);
         }

--- a/test/IbanNet.DependencyInjection.ServiceProvider.Tests/Specs/ShouldResolveCustomService.cs
+++ b/test/IbanNet.DependencyInjection.ServiceProvider.Tests/Specs/ShouldResolveCustomService.cs
@@ -19,10 +19,10 @@ public class ShouldResolveCustomService : TestHelpers.Specs.ShouldResolveCustomS
 
         protected override void Configure(IServiceCollection services, Action<IIbanNetOptionsBuilder> configurer)
         {
-            services.AddSingleton(Mock.Of<IIbanRegistry>());
-            services.AddSingleton(Mock.Of<IIbanParser>());
-            services.AddSingleton(Mock.Of<IIbanGenerator>());
-            services.AddSingleton(Mock.Of<IIbanValidator>());
+            services.AddSingleton(Substitute.For<IIbanRegistry>());
+            services.AddSingleton(Substitute.For<IIbanParser>());
+            services.AddSingleton(Substitute.For<IIbanGenerator>());
+            services.AddSingleton(Substitute.For<IIbanValidator>());
 
             base.Configure(services, configurer);
         }

--- a/test/IbanNet.FluentValidation.Tests/FluentIbanValidatorTests.cs
+++ b/test/IbanNet.FluentValidation.Tests/FluentIbanValidatorTests.cs
@@ -9,12 +9,12 @@ namespace IbanNet.FluentValidation;
 [Collection(nameof(SetsStaticValidator))]
 public class FluentIbanValidatorTests
 {
-    private readonly IbanValidatorStub _ibanValidatorStub;
+    private readonly IIbanValidator _ibanValidatorStub;
     private readonly TestModelValidator _validator;
 
     protected FluentIbanValidatorTests()
     {
-        _ibanValidatorStub = new IbanValidatorStub();
+        _ibanValidatorStub = IbanValidatorStub.Create();
         var sut = new FluentIbanValidator<TestModel>(_ibanValidatorStub);
         _validator = new TestModelValidator(sut);
     }
@@ -32,7 +32,7 @@ public class FluentIbanValidatorTests
             _validator.Validate(obj);
 
             // Assert
-            _ibanValidatorStub.Verify(m => m.Validate(AttemptedIbanValue), Times.Once);
+            _ibanValidatorStub.Received(1).Validate(AttemptedIbanValue);
         }
 
         [Fact]
@@ -72,7 +72,7 @@ public class FluentIbanValidatorTests
             _validator.Validate(obj);
 
             // Assert
-            _ibanValidatorStub.Verify(m => m.Validate(AttemptedIbanValue), Times.Once);
+            _ibanValidatorStub.Received(1).Validate(AttemptedIbanValue);
         }
 
         [Fact]
@@ -100,7 +100,7 @@ public class FluentIbanValidatorTests
             _validator.Validate(obj);
 
             // Assert
-            _ibanValidatorStub.Verify(m => m.Validate(It.IsAny<string>()), Times.Never);
+            _ibanValidatorStub.DidNotReceiveWithAnyArgs().Validate(default);
         }
 
         [Fact]

--- a/test/IbanNet.FluentValidation.Tests/RuleBuilderExtensionsTests.cs
+++ b/test/IbanNet.FluentValidation.Tests/RuleBuilderExtensionsTests.cs
@@ -11,7 +11,7 @@ public class RuleBuilderExtensionsTests
         IRuleBuilder<object, string>? ruleBuilder = null;
 
         // Act
-        Action act = () => ruleBuilder!.Iban(Mock.Of<IIbanValidator>());
+        Action act = () => ruleBuilder!.Iban(Substitute.For<IIbanValidator>());
 
         // Assert
         act.Should()
@@ -22,7 +22,7 @@ public class RuleBuilderExtensionsTests
     [Fact]
     public void Given_null_validator_when_registering_validator_it_should_throw()
     {
-        IRuleBuilder<object, string> ruleBuilder = Mock.Of<IRuleBuilder<object, string>>();
+        IRuleBuilder<object, string> ruleBuilder = Substitute.For<IRuleBuilder<object, string>>();
         IIbanValidator? ibanValidator = null;
 
         // Act
@@ -37,13 +37,13 @@ public class RuleBuilderExtensionsTests
     [Fact]
     public void When_registering_validator_it_should_add_validator_to_rule()
     {
-        var ruleBuilderMock = new Mock<IRuleBuilder<object, string>>();
-        IIbanValidator ibanValidator = Mock.Of<IIbanValidator>();
+        IRuleBuilder<object, string>? ruleBuilderMock = Substitute.For<IRuleBuilder<object, string>>();
+        IIbanValidator ibanValidator = Substitute.For<IIbanValidator>();
 
         // Act
-        ruleBuilderMock.Object.Iban(ibanValidator);
+        ruleBuilderMock.Iban(ibanValidator);
 
         // Assert
-        ruleBuilderMock.Verify(m => m.SetValidator(It.Is<IPropertyValidator<object, string>>(x => x is FluentIbanValidator<object>)), Times.Once);
+        ruleBuilderMock.Received(1).SetValidator(Arg.Is<IPropertyValidator<object, string>>(x => x is FluentIbanValidator<object>));
     }
 }

--- a/test/IbanNet.Tests/Builders/BuilderExtensionsTests.cs
+++ b/test/IbanNet.Tests/Builders/BuilderExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using IbanNet.Registry;
+using NSubstitute.Extensions;
 
 namespace IbanNet.Builders;
 
@@ -94,14 +95,17 @@ public class BuilderExtensionsTests
 
         public static IEnumerable<object?[]> WithCountryTestCases()
         {
-            IBankAccountBuilder builder = Mock.Of<IBankAccountBuilder>();
-            const string countryCode = "NL";
-            IIbanRegistry registry = Mock.Of<IIbanRegistry>();
+            IBankAccountBuilder builder = Substitute.For<IBankAccountBuilder>();
+            IIbanRegistry registry = Substitute.For<IIbanRegistry>();
 
-            IbanCountry? other = null;
-            var nl = new IbanCountry(countryCode);
-            Mock.Get(registry).Setup(m => m.TryGetValue(It.IsAny<string>(), out other));
-            Mock.Get(registry).Setup(m => m.TryGetValue("NL", out nl));
+            const string countryCode = "NL";
+            registry
+                .TryGetValue(countryCode, out Arg.Any<IbanCountry?>())
+                .Returns(x =>
+                {
+                    x[1] = new IbanCountry(countryCode);
+                    return true;
+                });
 
             yield return new object?[] { null, countryCode, registry, nameof(builder) };
             yield return new object?[] { builder, null, registry, nameof(countryCode) };

--- a/test/IbanNet.Tests/DependencyInjection/DependencyResolverAdapterTests.cs
+++ b/test/IbanNet.Tests/DependencyInjection/DependencyResolverAdapterTests.cs
@@ -6,7 +6,6 @@ namespace IbanNet.DependencyInjection;
 public class DependencyResolverAdapterTests
 {
     private readonly DependencyResolverAdapter _sut;
-    private readonly Mock<DependencyResolverAdapter> _adapterStub;
 
     private class TestService
     {
@@ -15,48 +14,45 @@ public class DependencyResolverAdapterTests
     public DependencyResolverAdapterTests()
     {
         _sut = CreateAdapterStub();
-        _adapterStub = Mock.Get(_sut);
     }
 
     private static DependencyResolverAdapter CreateAdapterStub()
     {
-        var adapterStub = new Mock<DependencyResolverAdapter> { CallBase = true };
+        DependencyResolverAdapter adapterStub = Substitute.For<DependencyResolverAdapter>();
         adapterStub
-            .Setup(m => m.GetService(It.IsAny<Type>()))
-            .Returns<Type>(Activator.CreateInstance);
-        return adapterStub.Object;
+            .GetService(Arg.Any<Type>())
+            .Returns(info => Activator.CreateInstance(info.Arg<Type>()));
+        return adapterStub;
     }
 
     [Fact]
     public void Given_service_is_not_registered_when_getting_generic_required_it_should_throw()
     {
-        _adapterStub
-            .Setup(m => m.GetService(It.IsAny<Type>()))
-            .Returns(null)
-            .Verifiable();
+        _sut
+            .GetService(Arg.Any<Type>())
+            .Returns(null);
 
         // Act
         Action act = () => _sut.GetRequiredService<TestService>();
 
         // Assert
         act.Should().Throw<InvalidOperationException>();
-        _adapterStub.Verify();
+        _sut.Received(1).GetService(Arg.Any<Type>());
     }
 
     [Fact]
     public void Given_service_is_not_registered_when_getting_required_it_should_throw()
     {
-        _adapterStub
-            .Setup(m => m.GetService(It.IsAny<Type>()))
-            .Returns(null)
-            .Verifiable();
+        _sut
+            .GetService(Arg.Any<Type>())
+            .Returns(null);
 
         // Act
         Action act = () => _sut.GetRequiredService(typeof(TestService));
 
         // Assert
         act.Should().Throw<InvalidOperationException>();
-        _adapterStub.Verify();
+        _sut.Received(1).GetService(Arg.Any<Type>());
     }
 
     [Theory]

--- a/test/IbanNet.Tests/DependencyInjection/FluentAssertions/IbanNetOptionsBuilderStubAssertions.cs
+++ b/test/IbanNet.Tests/DependencyInjection/FluentAssertions/IbanNetOptionsBuilderStubAssertions.cs
@@ -7,10 +7,10 @@ using TestHelpers.FluentAssertions;
 namespace IbanNet.DependencyInjection.FluentAssertions;
 
 public class IbanNetOptionsBuilderStubAssertions<T>
-    : ReferenceTypeAssertions<Mock<T>, IbanNetOptionsBuilderStubAssertions<T>>
+    : ReferenceTypeAssertions<T, IbanNetOptionsBuilderStubAssertions<T>>
     where T : class, IIbanNetOptionsBuilder
 {
-    public IbanNetOptionsBuilderStubAssertions(Mock<T> instance)
+    public IbanNetOptionsBuilderStubAssertions(T instance)
         : base(instance) { }
 
     protected override string Identifier => typeof(T).Name;
@@ -46,13 +46,13 @@ public class IbanNetOptionsBuilderStubAssertions<T>
         Func<Action<DependencyResolverAdapter, IbanValidatorOptions>, bool> assert = configureAction =>
         {
             var opts = new IbanValidatorOptions();
-            DependencyResolverAdapter adapter = new Mock<DependencyResolverAdapter>().Object;
+            DependencyResolverAdapter adapter = Substitute.For<DependencyResolverAdapter>();
             configureAction(adapter, opts);
 
             should(opts.Should());
             return true;
         };
 
-        Subject.Verify(m => m.Configure(It.Is<Action<DependencyResolverAdapter, IbanValidatorOptions>>(action => assert(action))));
+        Subject.Received().Configure(Arg.Is<Action<DependencyResolverAdapter, IbanValidatorOptions>>(action => assert(action)));
     }
 }

--- a/test/IbanNet.Tests/DependencyInjection/FluentAssertions/IbanNetOptionsBuilderStubExtensions.cs
+++ b/test/IbanNet.Tests/DependencyInjection/FluentAssertions/IbanNetOptionsBuilderStubExtensions.cs
@@ -2,7 +2,7 @@
 
 public static class IbanNetOptionsBuilderStubExtensions
 {
-    public static IbanNetOptionsBuilderStubAssertions<T> Should<T>(this Mock<T> instance)
+    public static IbanNetOptionsBuilderStubAssertions<T> Should<T>(this T instance)
         where T : class, IIbanNetOptionsBuilder
     {
         return new(instance);

--- a/test/IbanNet.Tests/DependencyInjection/IbanNetOptionsBuilderTests.cs
+++ b/test/IbanNet.Tests/DependencyInjection/IbanNetOptionsBuilderTests.cs
@@ -8,23 +8,21 @@ namespace IbanNet.DependencyInjection;
 
 public class IbanNetOptionsBuilderTests
 {
-    private readonly Mock<IIbanNetOptionsBuilder> _builderStub;
-    private readonly IIbanNetOptionsBuilder _builder;
+    private readonly IIbanNetOptionsBuilder _builderStub;
 
     protected IbanNetOptionsBuilderTests()
     {
-        _builder = GetBuilderStub();
-        _builderStub = Mock.Get(_builder);
+        _builderStub = GetBuilderStub();
     }
 
     private static IIbanNetOptionsBuilder GetBuilderStub()
     {
-        var builderMock = new Mock<IIbanNetOptionsBuilder>();
+        IIbanNetOptionsBuilder? builderMock = Substitute.For<IIbanNetOptionsBuilder>();
         builderMock
-            .Setup(m => m.Configure(It.IsAny<Action<DependencyResolverAdapter, IbanValidatorOptions>>()))
-            .Returns(builderMock.Object);
+            .Configure(Arg.Any<Action<DependencyResolverAdapter, IbanValidatorOptions>>())
+            .Returns(builderMock);
 
-        return builderMock.Object;
+        return builderMock;
     }
 
     public class ExtensionTests : IbanNetOptionsBuilderTests
@@ -37,7 +35,7 @@ public class IbanNetOptionsBuilderTests
                 .ToList();
 
             // Act
-            IIbanNetOptionsBuilder returnedBuilder = _builder.UseRegistry(new IbanRegistry
+            IIbanNetOptionsBuilder returnedBuilder = _builderStub.UseRegistry(new IbanRegistry
             {
                 Providers =
                 {
@@ -47,7 +45,7 @@ public class IbanNetOptionsBuilderTests
 
             // Assert
             _builderStub.Should().HaveConfiguredRegistry(limitedCountries);
-            returnedBuilder.Should().BeSameAs(_builderStub.Object);
+            returnedBuilder.Should().BeSameAs(_builderStub);
         }
 
         [Fact]
@@ -56,7 +54,7 @@ public class IbanNetOptionsBuilderTests
             var registry = new IbanRegistry();
 
             // Act
-            Action act = () => _builder.UseRegistry(registry);
+            Action act = () => _builderStub.UseRegistry(registry);
 
             // Assert
             act.Should()
@@ -71,11 +69,11 @@ public class IbanNetOptionsBuilderTests
             var customProvider = new IbanRegistryListProvider(new[] { new IbanCountry("XX") });
 
             // Act
-            IIbanNetOptionsBuilder returnedBuilder = _builder.UseRegistryProvider(customProvider);
+            IIbanNetOptionsBuilder returnedBuilder = _builderStub.UseRegistryProvider(customProvider);
 
             // Assert
             _builderStub.Should().HaveConfiguredRegistry(customProvider);
-            returnedBuilder.Should().BeSameAs(_builderStub.Object);
+            returnedBuilder.Should().BeSameAs(_builderStub);
         }
 
         [Fact]
@@ -84,11 +82,11 @@ public class IbanNetOptionsBuilderTests
             var customProvider = new IbanRegistryListProvider(new[] { new IbanCountry("XX") });
 
             // Act
-            IIbanNetOptionsBuilder returnedBuilder = _builder.UseRegistryProvider(new SwiftRegistryProvider(), customProvider);
+            IIbanNetOptionsBuilder returnedBuilder = _builderStub.UseRegistryProvider(new SwiftRegistryProvider(), customProvider);
 
             // Assert
             _builderStub.Should().HaveConfiguredRegistry(new SwiftRegistryProvider().Concat(customProvider));
-            returnedBuilder.Should().BeSameAs(_builderStub.Object);
+            returnedBuilder.Should().BeSameAs(_builderStub);
         }
 
         [Fact]
@@ -97,13 +95,13 @@ public class IbanNetOptionsBuilderTests
             var configuredRule = new TestValidationRule();
 
             // Act
-            IIbanNetOptionsBuilder returnedBuilder = _builder.WithRule(() => configuredRule);
+            IIbanNetOptionsBuilder returnedBuilder = _builderStub.WithRule(() => configuredRule);
 
             // Assert
             _builderStub.Should()
                 .HaveConfiguredRule<TestValidationRule>()
                 .And.Contain(configuredRule);
-            returnedBuilder.Should().BeSameAs(_builderStub.Object);
+            returnedBuilder.Should().BeSameAs(_builderStub);
         }
     }
 
@@ -133,7 +131,7 @@ public class IbanNetOptionsBuilderTests
                 DelegateTestCase.Create(
                     IbanNetOptionsBuilderExtensions.UseRegistry,
                     instance,
-                    Mock.Of<IIbanRegistry>()),
+                    Substitute.For<IIbanRegistry>()),
                 DelegateTestCase.Create(
                     IbanNetOptionsBuilderExtensions.UseRegistryProvider,
                     instance,

--- a/test/IbanNet.Tests/IbanParserTests.cs
+++ b/test/IbanNet.Tests/IbanParserTests.cs
@@ -6,12 +6,12 @@ namespace IbanNet;
 
 public class IbanParserTests
 {
-    private readonly IbanValidatorStub _ibanValidatorStub;
+    private readonly IIbanValidator _ibanValidatorStub;
     private readonly IbanParser _sut;
 
     protected IbanParserTests()
     {
-        _ibanValidatorStub = new IbanValidatorStub();
+        _ibanValidatorStub = IbanValidatorStub.Create();
         _sut = new IbanParser(_ibanValidatorStub);
     }
 
@@ -129,16 +129,15 @@ public class IbanParserTests
         {
             const string expectedNormalizedIban = "NL91ABNA0417164300";
             _ibanValidatorStub
-                .Setup(m => m.Validate(expectedNormalizedIban))
-                .Returns(new ValidationResult { AttemptedValue = iban, Country = new IbanCountry("NL") })
-                .Verifiable();
+                .Validate(Arg.Any<string>())
+                .Returns(new ValidationResult { AttemptedValue = iban, Country = new IbanCountry("NL") });
 
             // Act
             Iban actual = _sut.Parse(iban);
 
             // Assert
             actual.ToString().Should().Be(expectedNormalizedIban);
-            _ibanValidatorStub.Verify();
+            _ibanValidatorStub.Received(1).Validate(expectedNormalizedIban);
         }
 
         [Fact]
@@ -187,7 +186,7 @@ public class IbanParserTests
             ex.Result.Should().BeNull();
             ex.InnerException.Should().NotBeNull();
             ex.Message.Should().Contain("is not a valid IBAN.");
-            _ibanValidatorStub.Verify(m => m.Validate(TestValues.IbanForCustomRuleException), Times.Once);
+            _ibanValidatorStub.Received(1).Validate(TestValues.IbanForCustomRuleException);
         }
     }
 
@@ -214,7 +213,7 @@ public class IbanParserTests
             actual.Should().BeFalse("the provided value was invalid");
             iban.Should().BeNull("parsing did not succeed");
 
-            _ibanValidatorStub.Verify(m => m.Validate(TestValues.InvalidIban), Times.Once);
+            _ibanValidatorStub.Received(1).Validate(TestValues.InvalidIban);
         }
 
         [Fact]
@@ -232,7 +231,7 @@ public class IbanParserTests
                 .Should()
                 .Be(TestValues.ValidIban);
 
-            _ibanValidatorStub.Verify(m => m.Validate(TestValues.ValidIban), Times.Once);
+            _ibanValidatorStub.Received(1).Validate(TestValues.ValidIban);
         }
     }
 }

--- a/test/IbanNet.Tests/IbanTests.cs
+++ b/test/IbanNet.Tests/IbanTests.cs
@@ -135,7 +135,7 @@ public class IbanTests
 
         public When_comparing_for_equality()
         {
-            var ibanParser = new IbanParser(new IbanValidatorStub());
+            var ibanParser = new IbanParser(IbanValidatorStub.Create());
 
             _iban = ibanParser.Parse(TestValues.ValidIban);
             _equalIban = ibanParser.Parse(TestValues.ValidIbanPartitioned);
@@ -216,7 +216,7 @@ public class IbanTests
 
         public When_comparing_for_inequality()
         {
-            var ibanParser = new IbanParser(new IbanValidatorStub());
+            var ibanParser = new IbanParser(IbanValidatorStub.Create());
 
             _iban = ibanParser.Parse(TestValues.ValidIban);
             _equalIban = ibanParser.Parse(TestValues.ValidIbanPartitioned);

--- a/test/IbanNet.Tests/Registry/IbanRegistryTests.cs
+++ b/test/IbanNet.Tests/Registry/IbanRegistryTests.cs
@@ -120,7 +120,7 @@ public class IbanRegistryTests
         };
 
         // Act
-        Action act = () => sut.Providers.Add(Mock.Of<IIbanRegistryProvider>());
+        Action act = () => sut.Providers.Add(Substitute.For<IIbanRegistryProvider>());
 
         // Assert
         act.Should().NotThrow();
@@ -140,7 +140,7 @@ public class IbanRegistryTests
 
         // Act
         sut.Count.Should().BeGreaterThan(0); // Hydrate
-        Action act = () => sut.Providers.Add(Mock.Of<IIbanRegistryProvider>());
+        Action act = () => sut.Providers.Add(Substitute.For<IIbanRegistryProvider>());
 
         // Assert
         act.Should().Throw<NotSupportedException>()
@@ -162,7 +162,7 @@ public class IbanRegistryTests
         // Act
         IList<IIbanRegistryProvider> providerRef = sut.Providers;
         sut.Count.Should().BeGreaterThan(0); // Hydrate
-        providerRef.Add(Mock.Of<IIbanRegistryProvider>());
+        providerRef.Add(Substitute.For<IIbanRegistryProvider>());
 
         // Assert
         sut.Providers.Should().HaveCount(1);

--- a/test/IbanNet.Tests/TypeConverters/IbanTypeConverterTests.cs
+++ b/test/IbanNet.Tests/TypeConverters/IbanTypeConverterTests.cs
@@ -64,19 +64,15 @@ public abstract class IbanTypeConverterTests
         [Fact]
         public void Given_that_parser_can_be_resolved_when_converting_from_string_it_should_not_resolve_validator()
         {
-            var typeDescriptorContextMock = new Mock<ITypeDescriptorContext>();
-            typeDescriptorContextMock
-                .Setup(m => m.GetService(It.Is<Type>(t => t == typeof(IIbanParser))))
-                .Returns(new IbanParser(IbanRegistry.Default))
-                .Verifiable();
+            ITypeDescriptorContext typeDescriptorContextMock = Substitute.For<ITypeDescriptorContext>();
+            typeDescriptorContextMock.GetService(typeof(IIbanParser)).Returns(new IbanParser(IbanRegistry.Default));
 
             // Act
-            object? resultObj = _sut.ConvertFrom(typeDescriptorContextMock.Object, CultureInfo.InvariantCulture, TestValues.ValidIban);
+            object? resultObj = _sut.ConvertFrom(typeDescriptorContextMock, CultureInfo.InvariantCulture, TestValues.ValidIban);
 
             // Assert
-            typeDescriptorContextMock.Verify();
-            typeDescriptorContextMock
-                .Verify(m => m.GetService(It.Is<Type>(t => t == typeof(IIbanValidator))), Times.Never);
+            typeDescriptorContextMock.Received(1).GetService(typeof(IIbanParser));
+            typeDescriptorContextMock.DidNotReceive().GetService(typeof(IIbanValidator));
             resultObj.Should()
                 .NotBeNull()
                 .And.BeOfType<Iban>()
@@ -88,21 +84,16 @@ public abstract class IbanTypeConverterTests
         [Fact]
         public void Given_that_parser_cannot_be_resolved_when_converting_from_string_it_should_request_validator_next()
         {
-            var typeDescriptorContextMock = new Mock<ITypeDescriptorContext>();
-            typeDescriptorContextMock
-                .Setup(m => m.GetService(It.Is<Type>(t => t == typeof(IIbanParser))))
-                .Returns(null)
-                .Verifiable();
-            typeDescriptorContextMock
-                .Setup(m => m.GetService(It.Is<Type>(t => t == typeof(IIbanValidator))))
-                .Returns(new IbanValidator())
-                .Verifiable();
+            ITypeDescriptorContext typeDescriptorContextMock = Substitute.For<ITypeDescriptorContext>();
+            typeDescriptorContextMock.GetService(typeof(IIbanParser)).Returns(null);
+            typeDescriptorContextMock.GetService(typeof(IIbanValidator)).Returns(new IbanValidator());
 
             // Act
-            object? resultObj = _sut.ConvertFrom(typeDescriptorContextMock.Object, CultureInfo.InvariantCulture, TestValues.ValidIban);
+            object? resultObj = _sut.ConvertFrom(typeDescriptorContextMock, CultureInfo.InvariantCulture, TestValues.ValidIban);
 
             // Assert
-            typeDescriptorContextMock.Verify();
+            typeDescriptorContextMock.Received(1).GetService(typeof(IIbanParser));
+            typeDescriptorContextMock.Received(1).GetService(typeof(IIbanValidator));
             resultObj.Should()
                 .NotBeNull()
                 .And.BeOfType<Iban>()

--- a/test/IbanNet.Tests/Validation/DefaultValidationRuleResolverTests.cs
+++ b/test/IbanNet.Tests/Validation/DefaultValidationRuleResolverTests.cs
@@ -10,10 +10,10 @@ public class DefaultValidationRuleResolverTests
 
     public DefaultValidationRuleResolverTests()
     {
-        var registryMock = new Mock<IIbanRegistry>();
-        registryMock.Setup(m => m.Providers).Returns(new List<IIbanRegistryProvider>());
+        IIbanRegistry registryMock = Substitute.For<IIbanRegistry>();
+        registryMock.Providers.Returns(new List<IIbanRegistryProvider>());
         _customRules = new List<IIbanValidationRule>();
-        _sut = new DefaultValidationRuleResolver(registryMock.Object, _customRules);
+        _sut = new DefaultValidationRuleResolver(registryMock, _customRules);
     }
 
     [Fact]
@@ -44,8 +44,8 @@ public class DefaultValidationRuleResolverTests
     [Fact]
     public void Given_custom_rules_when_getting_rules_it_should_append_custom_rules()
     {
-        IIbanValidationRule rule1 = Mock.Of<IIbanValidationRule>();
-        IIbanValidationRule rule2 = Mock.Of<IIbanValidationRule>();
+        IIbanValidationRule rule1 = Substitute.For<IIbanValidationRule>();
+        IIbanValidationRule rule2 = Substitute.For<IIbanValidationRule>();
         _customRules.Add(rule1);
         _customRules.Add(rule2);
 

--- a/test/IbanNet.Tests/Validation/Rules/Mod97RuleTests.cs
+++ b/test/IbanNet.Tests/Validation/Rules/Mod97RuleTests.cs
@@ -6,12 +6,12 @@ namespace IbanNet.Validation.Rules;
 public class Mod97RuleTests
 {
     private readonly Mod97Rule _sut;
-    private readonly Mock<ICheckDigitsCalculator> _calculatorMock;
+    private readonly ICheckDigitsCalculator _calculatorMock;
 
     public Mod97RuleTests()
     {
-        _calculatorMock = new Mock<ICheckDigitsCalculator>();
-        _sut = new Mod97Rule(_calculatorMock.Object);
+        _calculatorMock = Substitute.For<ICheckDigitsCalculator>();
+        _sut = new Mod97Rule(_calculatorMock);
     }
 
     [Fact]
@@ -20,16 +20,15 @@ public class Mod97RuleTests
         const string value = "ABCD123456";
         const int invalidCheckDigit = 123;
         _calculatorMock
-            .Setup(m => m.Compute(It.Is<char[]>(buf => buf.SequenceEqual("123456ABCD"))))
-            .Returns(invalidCheckDigit)
-            .Verifiable();
+            .Compute(Arg.Is<char[]>(buf => buf.SequenceEqual("123456ABCD")))
+            .Returns(invalidCheckDigit);
 
         // Act
         ValidationRuleResult actual = _sut.Validate(new ValidationRuleContext(value));
 
         // Assert
         actual.Should().BeOfType<InvalidCheckDigitsResult>();
-        _calculatorMock.Verify();
+        _calculatorMock.ReceivedWithAnyArgs(1).Compute(default!);
     }
 
     [Fact]
@@ -38,15 +37,14 @@ public class Mod97RuleTests
         const string value = "ABCD123456";
         const int expectedCheckDigit = 1;
         _calculatorMock
-            .Setup(m => m.Compute(It.Is<char[]>(buf => buf.SequenceEqual("123456ABCD"))))
-            .Returns(expectedCheckDigit)
-            .Verifiable();
+            .Compute(Arg.Is<char[]>(buf => buf.SequenceEqual("123456ABCD")))
+            .Returns(expectedCheckDigit);
 
         // Act
         ValidationRuleResult actual = _sut.Validate(new ValidationRuleContext(value));
 
         // Assert
         actual.Should().Be(ValidationRuleResult.Success);
-        _calculatorMock.Verify();
+        _calculatorMock.ReceivedWithAnyArgs(1).Compute(default!);
     }
 }

--- a/test/TestHelpers/Specs/ConfiguredMultipleRulesSpec.cs
+++ b/test/TestHelpers/Specs/ConfiguredMultipleRulesSpec.cs
@@ -17,7 +17,7 @@ public abstract class ConfiguredMultipleRulesSpec : DiSpec
 
     protected override void Given()
     {
-        IIbanValidationRule fakeRule = Mock.Of<IIbanValidationRule>();
+        IIbanValidationRule fakeRule = Substitute.For<IIbanValidationRule>();
         _fakeRuleType = fakeRule.GetType();
         Fixture.Configure(builder =>
         {

--- a/test/TestHelpers/Specs/ShouldPreserveStaticValidatorSpec.cs
+++ b/test/TestHelpers/Specs/ShouldPreserveStaticValidatorSpec.cs
@@ -13,7 +13,7 @@ public abstract class ShouldPreserveStaticValidatorSpec : DiSpec
 
     protected override void Given()
     {
-        Iban.Validator = _initialValidator = Mock.Of<IIbanValidator>();
+        Iban.Validator = _initialValidator = Substitute.For<IIbanValidator>();
         Fixture.Configure(_ => { });
     }
 

--- a/test/TestHelpers/Specs/ShouldResolveCustomService.cs
+++ b/test/TestHelpers/Specs/ShouldResolveCustomService.cs
@@ -23,18 +23,12 @@ public abstract class ShouldResolveCustomService : DiSpec
     [InlineData(typeof(IIbanParser))]
     [InlineData(typeof(IIbanValidator))]
     [InlineData(typeof(IIbanGenerator))]
-    public void When_resolving_registry_it_should_not_throw(Type serviceType)
+    public void When_resolving_service_it_should_not_throw(Type serviceType)
     {
-        Type expectedMockType = typeof(IMocked<>).MakeGenericType(serviceType);
-
         // Assert
         Func<object?> act = () => Subject.GetService(serviceType);
 
         // Act
-        act.Should()
-            .NotThrow()
-            .Which
-            .Should()
-            .BeAssignableTo(expectedMockType);
+        act.Should().NotThrow();
     }
 }

--- a/test/TestHelpers/Specs/ShouldSetStaticValidatorSpec.cs
+++ b/test/TestHelpers/Specs/ShouldSetStaticValidatorSpec.cs
@@ -13,7 +13,7 @@ public abstract class ShouldSetStaticValidatorSpec : DiSpec
 
     protected override void Given()
     {
-        Iban.Validator = _initialValidator = Mock.Of<IIbanValidator>();
+        Iban.Validator = _initialValidator = Substitute.For<IIbanValidator>();
         Fixture.Configure(_ => { });
     }
 

--- a/test/TestHelpers/TestValues.cs
+++ b/test/TestHelpers/TestValues.cs
@@ -6,6 +6,6 @@ public static class TestValues
     public const string ValidIbanPartitioned = "AD12 0001 2030 2003 5910 0100";
     public const string ValidIbanPartitionedAndWithLowercase = "ad12 0001 2030 2003 5910 0100";
     public const string InvalidIban = "__INVALID_IBAN";
-    public static readonly string IbanForCustomRuleFailure = "CustomRuleFailure".ToUpperInvariant();
-    public static readonly  string IbanForCustomRuleException = "CustomRuleException".ToUpperInvariant();
+    public const string IbanForCustomRuleFailure = "CUSTOMRULEFAILURE";
+    public const string IbanForCustomRuleException = "CUSTOMRULEEXCEPTION";
 }


### PR DESCRIPTION
Due to addition of SponsorLink to Moq, I've decided to switch to NSubstitute. The GDPR/trust breach is concerning, but while this has since been resolved, it seems the author of Moq will continue to impose SponsorLink to anyone using his libraries and expose them to nag messages, longer build times, etc. I would love sponsorships too, but I do not agree with this method of getting financial compensation.

See https://github.com/moq/moq/issues/1372