### PR TITLE
ci: remove latest .NET SDK temporarily

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,42 +38,52 @@ jobs:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: |
-          7.0.307
-          6.0.x
-          5.0.x
-          3.1.x
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            7.0.x
+            6.0.x
+            5.0.x
+            3.1.x
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      - name: dotnet info
+        run: dotnet --info
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    # - name: Autobuild
-    #   uses: github/codeql-action/autobuild@v2
+      # https://github.com/actions/runner-images/blob/ubuntu22/20230821.1/images/linux/Ubuntu2204-Readme.md
+      # There is an issue with latest SDK on Linux with .NET Framework:
+      # https://github.com/microsoft/vstest/issues/4549
+      # Unfortunatey, it becomes preinstalled with latest GitHub runner images, so have to remove it for now.
+      - name: Remove latest .NET SDK (7.0.400)
+        run: sudo rm -rf ${DOTNET_ROOT}/sdk/7.0.400
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      # - name: Autobuild
+      #   uses: github/codeql-action/autobuild@v2
 
-    - name: Build
-      # Note: must include UseSharedCompilation=false
-      # https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/troubleshooting-the-codeql-workflow#no-code-found-during-the-build
-      run: |
-        dotnet build -c Release /p:UseSharedCompilation=false
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
+
+      - name: Build
+        # Note: must include UseSharedCompilation=false
+        # https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/troubleshooting-the-codeql-workflow#no-code-found-during-the-build
+        run: |
+          dotnet build -c Release /p:UseSharedCompilation=false
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -15,9 +15,20 @@ jobs:
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            7.0.307
+            7.0.x
             6.0.x
             5.0.x
             3.1.x
 
+      - name: dotnet info
+        run: dotnet --info
+
+      # https://github.com/actions/runner-images/blob/ubuntu22/20230821.1/images/linux/Ubuntu2204-Readme.md
+      # There is an issue with latest SDK on Linux with .NET Framework:
+      # https://github.com/microsoft/vstest/issues/4549
+      # Unfortunatey, it becomes preinstalled with latest GitHub runner images, so have to remove it for now.
+      - name: Remove latest .NET SDK (7.0.400)
+        if: matrix.os != 'windows-latest'
+        run: sudo rm -rf ${DOTNET_ROOT}/sdk/7.0.400
+    
       - run: dotnet test -c Release

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -22,10 +22,20 @@ jobs:
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            7.0.307
+            7.0.x
             6.0.x
             5.0.x
             3.1.x
+
+      - name: dotnet info
+        run: dotnet --info
+
+      # https://github.com/actions/runner-images/blob/ubuntu22/20230821.1/images/linux/Ubuntu2204-Readme.md
+      # There is an issue with latest SDK on Linux with .NET Framework:
+      # https://github.com/microsoft/vstest/issues/4549
+      # Unfortunatey, it becomes preinstalled with latest GitHub runner images, so have to remove it for now.
+      - name: Remove latest .NET SDK (7.0.400)
+        run: sudo rm -rf ${DOTNET_ROOT}/sdk/7.0.400
 
       - name: Install Sonar scanner
         run: dotnet tool install --global dotnet-sonarscanner


### PR DESCRIPTION
There is an issue with latest SDK (7.0.400) on Linux with .NET Framework causing builds with .NET Framework to fail. 
https://github.com/microsoft/vstest/issues/4549

Unfortunatey, it becomes preinstalled with latest [GitHub runner images](https://github.com/actions/runner-images/blob/ubuntu22/20230821.1/images/linux/Ubuntu2204-Readme.md), so have to remove it for now.

> Opting to lower version (eg. 7.0.307) via installer is not sufficient!