### PR TITLE
ci(deps): bump NodeJS/Java versions to fix deprecation warning of SonarScanner

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
+
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
@@ -37,6 +38,15 @@ jobs:
             6.0.x
             5.0.x
             3.1.x
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "17"
 
       - name: dotnet info
         run: dotnet --info


### PR DESCRIPTION
Fixes warning:

> The version of Java (11.0.20) you have used to run this analysis is deprecated and we will stop accepting it soon. Please update to at least Java 17. Read more [here](https://docs.sonarcloud.io/appendices/scanner-environment/)