### PR TITLE
ci(sonar): PR decoration was broken

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -61,12 +61,20 @@ jobs:
           echo "SONAR_PROJECT_KEY=${GITHUB_REPOSITORY_OWNER}_${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
           echo "SONAR_ORG_KEY=${GITHUB_REPOSITORY_OWNER}" >> $GITHUB_ENV
 
+      - name: SonarCloud PR config
+        if: github.event_name == 'pull_request_target'
+        run: |
+          echo "SONAR_PR_ARGS=\
+          /d:sonar.pullrequest.key=${{ github.event.pull_request.id }} \
+          /d:sonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} \
+          /d:sonar.pullrequest.base=${{ github.event.pull_request.base.ref }}"
+
       - name: Analyze with SonarCloud
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          dotnet sonarscanner begin /k:"$SONAR_PROJECT_KEY" /o:"$SONAR_ORG_KEY" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="$SONAR_TOKEN" /d:sonar.cs.opencover.reportsPaths="**/*opencover.xml"
+          dotnet sonarscanner begin /k:"$SONAR_PROJECT_KEY" /o:"$SONAR_ORG_KEY" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="$SONAR_TOKEN" /d:sonar.cs.opencover.reportsPaths="**/*opencover.xml" $SONAR_PR_ARGS
 
           dotnet test -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByFile="test/**/*.cs"
 


### PR DESCRIPTION
PR decoration was broken due to a previous change (6065d99) where we now check out detached PR head. Because of this, I assume SonarQube is unable to determine branch and target and thus not decorating the PR.

Fix by explicitly providing PR nr and branches