### PR TITLE
feat(net8): add .NET 8 target framework

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,7 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_NOLOGO: true
   dotnet-version: |
+    8.0.x
     7.0.x
     6.0.x
     5.0.x
@@ -51,10 +52,7 @@ jobs:
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ env.dotnet-version }}
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: '8.0.x'
-          dotnet-quality: 'preview'
+
       - run: dotnet --info
 
       # Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_NOLOGO: true
   dotnet-version: |
+    8.0.x
     7.0.x
     6.0.x
     5.0.x
@@ -63,10 +64,7 @@ jobs:
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ env.dotnet-version }}
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: '8.0.x'
-          dotnet-quality: 'preview'
+
       - run: dotnet --info
 
       # Checkout
@@ -113,10 +111,6 @@ jobs:
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ env.dotnet-version }}
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: '8.0.x'
-          dotnet-quality: 'preview'
 
       # Checkout
       - uses: actions/checkout@v4
@@ -142,10 +136,6 @@ jobs:
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ env.dotnet-version }}
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: '8.0.x'
-          dotnet-quality: 'preview'
 
       # Checkout
       - uses: actions/checkout@v4

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -13,6 +13,7 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_NOLOGO: true
   dotnet-version: |
+    8.0.x
     7.0.x
     6.0.x
     5.0.x
@@ -36,10 +37,7 @@ jobs:
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ env.dotnet-version }}
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: '8.0.x'
-          dotnet-quality: 'preview'
+
       - run: dotnet --info
 
       - uses: actions/setup-node@v3

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefineConstants Condition="'$(TargetFramework)'=='net7.0' Or '$(TargetFramework)'=='net6.0' Or '$(TargetFramework)'=='net5.0' Or '$(TargetFramework)'=='netstandard2.1'">$(DefineConstants);USE_SPANS</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)'=='net8.0' Or '$(TargetFramework)'=='net7.0' Or '$(TargetFramework)'=='net6.0' Or '$(TargetFramework)'=='net5.0' Or '$(TargetFramework)'=='netstandard2.1'">$(DefineConstants);USE_SPANS</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <MicrosoftExtensionsVersion>8.0.0</MicrosoftExtensionsVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net7.0'">

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -18,10 +18,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Nullable" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/IbanNet.DataAnnotations/IbanNet.DataAnnotations.csproj
+++ b/src/IbanNet.DataAnnotations/IbanNet.DataAnnotations.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;netstandard1.6;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;netstandard1.6;net472;net462</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/IbanNet.DependencyInjection.Autofac/IbanNet.DependencyInjection.Autofac.csproj
+++ b/src/IbanNet.DependencyInjection.Autofac/IbanNet.DependencyInjection.Autofac.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1014</NoWarn>
   </PropertyGroup>
 

--- a/src/IbanNet.DependencyInjection.ServiceProvider/IbanNet.DependencyInjection.ServiceProvider.csproj
+++ b/src/IbanNet.DependencyInjection.ServiceProvider/IbanNet.DependencyInjection.ServiceProvider.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1014</NoWarn>
   </PropertyGroup>
 

--- a/src/IbanNet.FluentValidation/IbanNet.FluentValidation.csproj
+++ b/src/IbanNet.FluentValidation/IbanNet.FluentValidation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/IbanNet/IbanNet.csproj
+++ b/src/IbanNet/IbanNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0;netstandard1.6;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;netstandard1.6;net472;net462</TargetFrameworks>
     <AllowUnsafeBlocks Condition="!$(DefineConstants.Contains('USE_SPANS'))">true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);CA1052;CA1031</NoWarn>
   </PropertyGroup>

--- a/test/IbanNet.Benchmark/BenchmarkResults.md
+++ b/test/IbanNet.Benchmark/BenchmarkResults.md
@@ -5,22 +5,24 @@
 A single validation:
 
 ```
-BenchmarkDotNet=v0.13.5, OS=Windows 10 (10.0.19045.2846/22H2/2022Update)
+BenchmarkDotNet v0.13.9+228a464e8be6c580ad9408e98f18813f6407fb5a, Windows 10 (10.0.19045.3570/22H2/2022Update)
 Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
-.NET SDK=7.0.203
-  [Host]     : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
-  Job-FSXHEA : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
-  Job-SUVHVP : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2
-  Job-RGIAGU : .NET Core 3.1.32 (CoreCLR 4.700.22.55902, CoreFX 4.700.22.56512), X64 RyuJIT AVX2
-  Job-EMDPBD : .NET Framework 4.8 (4.8.4614.0), X64 RyuJIT VectorSize=256
+.NET SDK 8.0.100-rc.2.23502.2
+  [Host]     : .NET 8.0.0 (8.0.23.47906), X64 RyuJIT AVX2
+  Job-KKHTHD : .NET 8.0.0 (8.0.23.47906), X64 RyuJIT AVX2
+  Job-JRRQIK : .NET 7.0.12 (7.0.1223.47720), X64 RyuJIT AVX2
+  Job-AHKJZW : .NET 6.0.24 (6.0.2423.51814), X64 RyuJIT AVX2
+  Job-CWCIQA : .NET Core 3.1.32 (CoreCLR 4.700.22.55902, CoreFX 4.700.22.56512), X64 RyuJIT AVX2
+  Job-ALVDSL : .NET Framework 4.8.1 (4.8.9181.0), X64 RyuJIT VectorSize=256
 ```
 
-|   Method |            Runtime |     Mean |   Error |  StdDev |   Median | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
-|--------- |------------------- |---------:|--------:|--------:|---------:|------:|--------:|-------:|----------:|------------:|
-| Validate |           .NET 7.0 | 268.4 ns | 5.34 ns | 8.15 ns | 264.4 ns |  1.00 |    0.00 | 0.0277 |     176 B |        1.00 |
-| Validate |           .NET 6.0 | 285.8 ns | 3.48 ns | 3.25 ns | 286.4 ns |  1.05 |    0.04 | 0.0277 |     176 B |        1.00 |
-| Validate |      .NET Core 3.1 | 341.0 ns | 6.15 ns | 5.13 ns | 338.9 ns |  1.25 |    0.03 | 0.0277 |     176 B |        1.00 |
-| Validate | .NET Framework 4.8 | 366.3 ns | 1.97 ns | 1.75 ns | 366.6 ns |  1.35 |    0.05 | 0.0277 |     177 B |        1.01 |
+| Method   | Runtime            | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|--------- |------------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
+| Validate | .NET 8.0           | 255.3 ns | 4.96 ns | 5.10 ns |  1.00 |    0.00 | 0.0305 |     192 B |        1.00 |
+| Validate | .NET 7.0           | 271.0 ns | 2.77 ns | 2.31 ns |  1.06 |    0.03 | 0.0277 |     176 B |        0.92 |
+| Validate | .NET 6.0           | 284.5 ns | 3.25 ns | 3.04 ns |  1.11 |    0.02 | 0.0277 |     176 B |        0.92 |
+| Validate | .NET Core 3.1      | 344.6 ns | 2.87 ns | 2.54 ns |  1.35 |    0.03 | 0.0277 |     176 B |        0.92 |
+| Validate | .NET Framework 4.8 | 367.7 ns | 1.03 ns | 0.80 ns |  1.44 |    0.03 | 0.0277 |     177 B |        0.92 |
 
 
 ### Comparison with other validators
@@ -33,28 +35,33 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
 - *Singleton*: strict validation, singleton validator
 - *Transient*: strict validation, transient validator (per validation). Notice the extra allocations/GC. This is not recommended, and purely for demonstration.
 
-|               Method |            Runtime | Count |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD |      Gen0 | Allocated | Alloc Ratio |
-|--------------------- |------------------- |------ |----------:|----------:|----------:|----------:|------:|--------:|----------:|----------:|------------:|
-| Singleton_CacheReuse |           .NET 7.0 | 10000 |  2.672 ms | 0.0069 ms | 0.0061 ms |  2.672 ms |  0.78 |    0.00 |  277.3438 |   1.68 MB |        0.99 |
-| Singleton_CacheReuse |           .NET 6.0 | 10000 |  2.684 ms | 0.0091 ms | 0.0071 ms |  2.685 ms |  0.78 |    0.00 |  277.3438 |   1.68 MB |        0.99 |
-| Singleton_CacheReuse |      .NET Core 3.1 | 10000 |  3.354 ms | 0.0525 ms | 0.0465 ms |  3.339 ms |  0.97 |    0.01 |  277.3438 |   1.68 MB |        0.99 |
-|            Singleton |           .NET 7.0 | 10000 |  3.446 ms | 0.0069 ms | 0.0065 ms |  3.445 ms |  1.00 |    0.00 |  281.2500 |    1.7 MB |        1.00 |
-| Singleton_CacheReuse | .NET Framework 4.8 | 10000 |  3.518 ms | 0.0428 ms | 0.0358 ms |  3.498 ms |  1.02 |    0.01 |  277.3438 |   1.68 MB |        0.99 |
-|            Singleton |           .NET 6.0 | 10000 |  3.589 ms | 0.0109 ms | 0.0091 ms |  3.585 ms |  1.04 |    0.00 |  281.2500 |    1.7 MB |        1.00 |
-|            Singleton |      .NET Core 3.1 | 10000 |  4.208 ms | 0.0100 ms | 0.0089 ms |  4.212 ms |  1.22 |    0.00 |  281.2500 |    1.7 MB |        1.00 |
-|            Singleton | .NET Framework 4.8 | 10000 |  4.350 ms | 0.0169 ms | 0.0158 ms |  4.353 ms |  1.26 |    0.00 |  281.2500 |   1.71 MB |        1.00 |
-|            Transient |           .NET 7.0 | 10000 |  5.832 ms | 0.0207 ms | 0.0162 ms |  5.833 ms |  1.69 |    0.01 | 1250.0000 |    7.5 MB |        4.41 |
-|            Transient |           .NET 6.0 | 10000 |  6.093 ms | 0.0200 ms | 0.0167 ms |  6.097 ms |  1.77 |    0.01 | 1250.0000 |    7.5 MB |        4.41 |
-|            Transient |      .NET Core 3.1 | 10000 |  7.046 ms | 0.0185 ms | 0.0164 ms |  7.044 ms |  2.04 |    0.01 | 1250.0000 |    7.5 MB |        4.41 |
-|            Transient | .NET Framework 4.8 | 10000 |  7.529 ms | 0.0730 ms | 0.0610 ms |  7.510 ms |  2.18 |    0.02 | 1273.4375 |   7.68 MB |        4.51 |
-|  NuGet_IbanValidator |           .NET 6.0 | 10000 | 14.384 ms | 0.2862 ms | 0.5974 ms | 14.129 ms |  4.33 |    0.22 | 3500.0000 |  20.95 MB |       12.30 |
-|  NuGet_IbanValidator |           .NET 7.0 | 10000 | 15.251 ms | 0.0512 ms | 0.0399 ms | 15.257 ms |  4.42 |    0.01 | 3500.0000 |  20.95 MB |       12.30 |
-|       NuGet_IBAN4NET |           .NET 7.0 | 10000 | 33.835 ms | 0.2105 ms | 0.1757 ms | 33.789 ms |  9.82 |    0.06 | 1666.6667 |  10.36 MB |        6.09 |
-|       NuGet_IBAN4NET |           .NET 6.0 | 10000 | 36.158 ms | 0.6958 ms | 0.6509 ms | 36.122 ms | 10.49 |    0.19 | 1714.2857 |  10.36 MB |        6.09 |
-|  NuGet_IbanValidator |      .NET Core 3.1 | 10000 | 38.064 ms | 0.4709 ms | 0.4404 ms | 37.905 ms | 11.05 |    0.13 | 8428.5714 |  50.45 MB |       29.63 |
-|       NuGet_IBAN4NET |      .NET Core 3.1 | 10000 | 38.723 ms | 0.0543 ms | 0.0453 ms | 38.737 ms | 11.24 |    0.03 | 1692.3077 |  10.36 MB |        6.09 |
-|  NuGet_IbanValidator | .NET Framework 4.8 | 10000 | 52.702 ms | 0.4519 ms | 0.4227 ms | 52.538 ms | 15.29 |    0.14 | 6800.0000 |  41.33 MB |       24.27 |
-|       NuGet_IBAN4NET | .NET Framework 4.8 | 10000 | 54.086 ms | 1.0518 ms | 0.9838 ms | 54.180 ms | 15.69 |    0.27 | 2000.0000 |  12.24 MB |        7.19 |
+| Method               | Runtime            | Count | Mean      | Error     | StdDev    | Ratio | RatioSD | Gen0      | Allocated | Alloc Ratio |
+|--------------------- |------------------- |------ |----------:|----------:|----------:|------:|--------:|----------:|----------:|------------:|
+| Singleton_CacheReuse | .NET 8.0           | 10000 |  2.672 ms | 0.0507 ms | 0.0564 ms |  0.82 |    0.03 |  304.6875 |   1.83 MB |        1.08 |
+| Singleton_CacheReuse | .NET 6.0           | 10000 |  2.825 ms | 0.0562 ms | 0.0552 ms |  0.87 |    0.03 |  277.3438 |   1.68 MB |        0.99 |
+| Singleton_CacheReuse | .NET 7.0           | 10000 |  2.831 ms | 0.0467 ms | 0.0390 ms |  0.87 |    0.03 |  277.3438 |   1.68 MB |        0.99 |
+| Singleton            | .NET 8.0           | 10000 |  3.255 ms | 0.0639 ms | 0.0831 ms |  1.00 |    0.00 |  281.2500 |    1.7 MB |        1.00 |
+| Singleton_CacheReuse | .NET Core 3.1      | 10000 |  3.462 ms | 0.0385 ms | 0.0360 ms |  1.07 |    0.03 |  277.3438 |   1.68 MB |        0.99 |
+| Singleton            | .NET 7.0           | 10000 |  3.598 ms | 0.0669 ms | 0.0657 ms |  1.11 |    0.05 |  281.2500 |    1.7 MB |        1.00 |
+| Singleton            | .NET 6.0           | 10000 |  3.710 ms | 0.0576 ms | 0.0538 ms |  1.14 |    0.04 |  281.2500 |    1.7 MB |        1.00 |
+| Singleton_CacheReuse | .NET Framework 4.8 | 10000 |  3.726 ms | 0.0138 ms | 0.0122 ms |  1.15 |    0.03 |  277.3438 |   1.68 MB |        0.99 |
+| Singleton            | .NET Core 3.1      | 10000 |  4.400 ms | 0.0197 ms | 0.0164 ms |  1.36 |    0.04 |  281.2500 |    1.7 MB |        1.00 |
+| Singleton            | .NET Framework 4.8 | 10000 |  4.639 ms | 0.0310 ms | 0.0275 ms |  1.43 |    0.04 |  281.2500 |   1.71 MB |        1.00 |
+| Transient            | .NET 8.0           | 10000 |  5.590 ms | 0.0703 ms | 0.0657 ms |  1.72 |    0.05 | 1195.3125 |   7.19 MB |        4.23 |
+| Transient            | .NET 6.0           | 10000 |  6.464 ms | 0.1194 ms | 0.1117 ms |  1.99 |    0.07 | 1265.6250 |   7.58 MB |        4.45 |
+| Transient            | .NET 7.0           | 10000 |  6.489 ms | 0.1261 ms | 0.2142 ms |  2.02 |    0.08 | 1265.6250 |   7.58 MB |        4.45 |
+| Transient            | .NET Core 3.1      | 10000 |  7.422 ms | 0.0394 ms | 0.0329 ms |  2.29 |    0.07 | 1265.6250 |   7.58 MB |        4.45 |
+| Transient            | .NET Framework 4.8 | 10000 |  7.752 ms | 0.0908 ms | 0.0805 ms |  2.39 |    0.06 | 1289.0625 |   7.75 MB |        4.56 |
+| NuGet_IbanValidator  | .NET 8.0           | 10000 | 13.739 ms | 0.1706 ms | 0.1513 ms |  4.24 |    0.14 | 3062.5000 |  18.38 MB |       10.81 |
+| NuGet_IbanValidator  | .NET 6.0           | 10000 | 14.225 ms | 0.2840 ms | 0.4975 ms |  4.44 |    0.19 | 3375.0000 |  20.21 MB |       11.88 |
+| NuGet_IbanValidator  | .NET 7.0           | 10000 | 15.817 ms | 0.3072 ms | 0.3287 ms |  4.86 |    0.15 | 3375.0000 |  20.21 MB |       11.88 |
+| NuGet_IBAN4NET       | .NET 8.0           | 10000 | 29.135 ms | 0.5341 ms | 0.9494 ms |  9.03 |    0.31 | 1687.5000 |  10.18 MB |        5.99 |
+| NuGet_IBAN4NET       | .NET 6.0           | 10000 | 36.407 ms | 0.7124 ms | 0.6664 ms | 11.20 |    0.39 | 1642.8571 |  10.19 MB |        5.99 |
+| NuGet_IBAN4NET       | .NET 7.0           | 10000 | 36.707 ms | 0.3702 ms | 0.3463 ms | 11.29 |    0.30 | 1642.8571 |  10.19 MB |        5.99 |
+| NuGet_IbanValidator  | .NET Core 3.1      | 10000 | 38.961 ms | 0.7167 ms | 0.6353 ms | 12.01 |    0.37 | 8076.9231 |  48.67 MB |       28.62 |
+| NuGet_IBAN4NET       | .NET Core 3.1      | 10000 | 40.821 ms | 0.4082 ms | 0.3819 ms | 12.56 |    0.33 | 1666.6667 |  10.19 MB |        5.99 |
+| NuGet_IBAN4NET       | .NET Framework 4.8 | 10000 | 55.719 ms | 0.1811 ms | 0.1512 ms | 17.19 |    0.50 | 2000.0000 |  12.05 MB |        7.08 |
+| NuGet_IbanValidator  | .NET Framework 4.8 | 10000 | 55.832 ms | 0.2081 ms | 0.1738 ms | 17.23 |    0.51 | 6555.5556 |  39.89 MB |       23.45 |
 
 
 ### CLI
@@ -62,5 +69,5 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
 To run the benchmark:
 ```
 cd ./test/IbanNet.Benchmark
-dotnet run -c Release -f net7.0 net6.0 netcoreapp3.1 net472 --runtimes net70 net60 netcoreapp31 net48 /p:AllValidators=1
+dotnet run -c Release -f net8.0 --runtimes net80 net70 net60 netcoreapp31 net48
 ```

--- a/test/IbanNet.Benchmark/IbanNet.Benchmark.csproj
+++ b/test/IbanNet.Benchmark/IbanNet.Benchmark.csproj
@@ -5,8 +5,7 @@
     <TargetFrameworks>net8.0;net7.0;net6.0;netcoreapp3.1;net472</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
     <Nullable>disable</Nullable>
-    <Configurations>Debug;Release;ComparisonRelease</Configurations>
-    <DefineConstants Condition="'$(AllValidators)'!=''">$(DefineConstants);VALIDATOR_COMPARISONS</DefineConstants>
+    <DefineConstants Condition="'$(Configuration)'=='Release' And '$(ContinuousIntegrationBuild)'==''">$(DefineConstants);VALIDATOR_COMPARISONS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IbanNet.Benchmark/IbanNet.Benchmark.csproj
+++ b/test/IbanNet.Benchmark/IbanNet.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netcoreapp3.1;net472</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
     <Nullable>disable</Nullable>
     <Configurations>Debug;Release;ComparisonRelease</Configurations>

--- a/test/IbanNet.Benchmark/ValidatorBenchmark.cs
+++ b/test/IbanNet.Benchmark/ValidatorBenchmark.cs
@@ -11,7 +11,7 @@ namespace IbanNet.Benchmark;
 [MemoryDiagnoser]
 public class ValidatorBenchmark
 {
-    private IIbanValidator _validator;
+    private IbanValidator _validator;
 #if VALIDATOR_COMPARISONS
     private IbanValidation.IbanValidator _nugetIbanValidator;
 #endif

--- a/test/IbanNet.CodeGen.Tests/IbanNet.CodeGen.Tests.csproj
+++ b/test/IbanNet.CodeGen.Tests/IbanNet.CodeGen.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/test/IbanNet.DataAnnotations.Tests/IbanNet.DataAnnotations.Tests.csproj
+++ b/test/IbanNet.DataAnnotations.Tests/IbanNet.DataAnnotations.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1;net48;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;net48;net472;net462</TargetFrameworks>
 
     <IsTestProject>true</IsTestProject>
 
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=net8.0" Condition="'$(TargetFramework)'=='net8.0'" />
     <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=net7.0" Condition="'$(TargetFramework)'=='net7.0'" />
     <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=net6.0" Condition="'$(TargetFramework)'=='net6.0'" />
     <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=netstandard2.1" Condition="'$(TargetFramework)'=='net5.0'" />
@@ -19,6 +20,10 @@
     <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=net462" Condition="'$(TargetFramework)'=='net462'" />
     <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.ServiceProvider\IbanNet.DependencyInjection.ServiceProvider.csproj" />
     <ProjectReference Include="..\TestHelpers\TestHelpers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-rc.2.23480.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net7.0'">

--- a/test/IbanNet.DependencyInjection.Autofac.Tests/IbanNet.DependencyInjection.Autofac.Tests.csproj
+++ b/test/IbanNet.DependencyInjection.Autofac.Tests/IbanNet.DependencyInjection.Autofac.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
 
     <IsTestProject>true</IsTestProject>
 
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.Autofac\IbanNet.DependencyInjection.Autofac.csproj" AdditionalProperties="TargetFramework=net8.0" Condition="'$(TargetFramework)'=='net8.0'" />
     <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.Autofac\IbanNet.DependencyInjection.Autofac.csproj" AdditionalProperties="TargetFramework=net7.0" Condition="'$(TargetFramework)'=='net7.0'" />
     <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.Autofac\IbanNet.DependencyInjection.Autofac.csproj" AdditionalProperties="TargetFramework=net6.0" Condition="'$(TargetFramework)'=='net6.0'" />
     <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.Autofac\IbanNet.DependencyInjection.Autofac.csproj" AdditionalProperties="TargetFramework=netstandard2.1" Condition="'$(TargetFramework)'=='net5.0'" />

--- a/test/IbanNet.DependencyInjection.ServiceProvider.Tests/IbanNet.DependencyInjection.ServiceProvider.Tests.csproj
+++ b/test/IbanNet.DependencyInjection.ServiceProvider.Tests/IbanNet.DependencyInjection.ServiceProvider.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
 
     <IsTestProject>true</IsTestProject>
 
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.ServiceProvider\IbanNet.DependencyInjection.ServiceProvider.csproj" AdditionalProperties="TargetFramework=net8.0" Condition="'$(TargetFramework)'=='net8.0'" />
     <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.ServiceProvider\IbanNet.DependencyInjection.ServiceProvider.csproj" AdditionalProperties="TargetFramework=net7.0" Condition="'$(TargetFramework)'=='net7.0'" />
     <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.ServiceProvider\IbanNet.DependencyInjection.ServiceProvider.csproj" AdditionalProperties="TargetFramework=net6.0" Condition="'$(TargetFramework)'=='net6.0'" />
     <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.ServiceProvider\IbanNet.DependencyInjection.ServiceProvider.csproj" AdditionalProperties="TargetFramework=netstandard2.1" Condition="'$(TargetFramework)'=='net5.0'" />

--- a/test/IbanNet.FluentValidation.Tests/IbanNet.FluentValidation.Tests.csproj
+++ b/test/IbanNet.FluentValidation.Tests/IbanNet.FluentValidation.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
 
     <IsTestProject>true</IsTestProject>
 
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\IbanNet.FluentValidation\IbanNet.FluentValidation.csproj" AdditionalProperties="TargetFramework=net8.0" Condition="'$(TargetFramework)'=='net8.0'" />
     <ProjectReference Include="..\..\src\IbanNet.FluentValidation\IbanNet.FluentValidation.csproj" AdditionalProperties="TargetFramework=net7.0" Condition="'$(TargetFramework)'=='net7.0'" />
     <ProjectReference Include="..\..\src\IbanNet.FluentValidation\IbanNet.FluentValidation.csproj" AdditionalProperties="TargetFramework=net6.0" Condition="'$(TargetFramework)'=='net6.0'" />
     <ProjectReference Include="..\..\src\IbanNet.FluentValidation\IbanNet.FluentValidation.csproj" AdditionalProperties="TargetFramework=netstandard2.1" Condition="'$(TargetFramework)'=='net5.0'" />

--- a/test/IbanNet.Tests/IbanNet.Tests.csproj
+++ b/test/IbanNet.Tests/IbanNet.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1;net48;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;net48;net472;net462</TargetFrameworks>
 
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);xUnit1026</NoWarn>
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\IbanNet\IbanNet.csproj" AdditionalProperties="TargetFramework=net8.0" Condition="'$(TargetFramework)'=='net8.0'" />
     <ProjectReference Include="..\..\src\IbanNet\IbanNet.csproj" AdditionalProperties="TargetFramework=net7.0" Condition="'$(TargetFramework)'=='net7.0'" />
     <ProjectReference Include="..\..\src\IbanNet\IbanNet.csproj" AdditionalProperties="TargetFramework=net6.0" Condition="'$(TargetFramework)'=='net6.0'" />
     <ProjectReference Include="..\..\src\IbanNet\IbanNet.csproj" AdditionalProperties="TargetFramework=netstandard2.1" Condition="'$(TargetFramework)'=='net5.0'" />

--- a/test/TestHelpers/TestHelpers.csproj
+++ b/test/TestHelpers/TestHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netstandard2.0;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netstandard2.0;net472;net462</TargetFrameworks>
     
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>


### PR DESCRIPTION
- Adds .NET 8 target framework
- Uses new `FrozenDictionary<,>` in `IbanRegistry`
- Retested for performance regressions/improvements

> The AppVeyor build will break as it is missing .NET 8 preview.