### PR TITLE
chore: reduce build runtime by excluding satellite assemblies (in tests)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,9 @@
     <NoWarn Condition="'$(Configuration)'=='Release'">$(NoWarn);NETSDK1138</NoWarn>
     <WarningsAsErrors>$(WarningsAsErrors);NU1601;NU1603;NU1605;NU1608;NU1701;MSB3644</WarningsAsErrors>
     <ContinuousIntegrationBuild Condition="'$(CI)'!=''">true</ContinuousIntegrationBuild>
+
+    <!-- Ignoring all satelite assemblies from external dependencies to reduce build artifact size. -->
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/IbanNet.DataAnnotations/IbanNet.DataAnnotations.csproj
+++ b/src/IbanNet.DataAnnotations/IbanNet.DataAnnotations.csproj
@@ -41,11 +41,15 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <EmbeddedResource Update="Resources.nl.resx">
+    <EmbeddedResource Update="Resources.ca.resx">
       <SubType>Designer</SubType>
       <DependentUpon>Resources.resx</DependentUpon>
     </EmbeddedResource>
-    <EmbeddedResource Update="Resources.ca.resx">
+    <EmbeddedResource Update="Resources.de.resx">
+      <SubType>Designer</SubType>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources.nl.resx">
       <SubType>Designer</SubType>
       <DependentUpon>Resources.resx</DependentUpon>
     </EmbeddedResource>

--- a/src/IbanNet.FluentValidation/IbanNet.FluentValidation.csproj
+++ b/src/IbanNet.FluentValidation/IbanNet.FluentValidation.csproj
@@ -41,11 +41,15 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <EmbeddedResource Update="Resources.nl.resx">
+    <EmbeddedResource Update="Resources.ca.resx">
       <SubType>Designer</SubType>
       <DependentUpon>Resources.resx</DependentUpon>
     </EmbeddedResource>
-    <EmbeddedResource Update="Resources.ca.resx">
+    <EmbeddedResource Update="Resources.de.resx">
+      <SubType>Designer</SubType>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources.nl.resx">
       <SubType>Designer</SubType>
       <DependentUpon>Resources.resx</DependentUpon>
     </EmbeddedResource>

--- a/src/IbanNet/IbanNet.csproj
+++ b/src/IbanNet/IbanNet.csproj
@@ -55,11 +55,15 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <EmbeddedResource Update="Resources.nl.resx">
+    <EmbeddedResource Update="Resources.ca.resx">
       <SubType>Designer</SubType>
       <DependentUpon>Resources.resx</DependentUpon>
     </EmbeddedResource>
-    <EmbeddedResource Update="Resources.ca.resx">
+    <EmbeddedResource Update="Resources.de.resx">
+      <SubType>Designer</SubType>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources.nl.resx">
       <SubType>Designer</SubType>
       <DependentUpon>Resources.resx</DependentUpon>
     </EmbeddedResource>


### PR DESCRIPTION
chore: reduce build runtime by excluding satellite assemblies (in tests)
style: move DE satellite RESX under the parent RESX (this does not affect `dotnet pack` of our runtime assemblies)