### PR TITLE
fix(xUnit1012): address static code analysis

### DIFF
--- a/test/IbanNet.Tests/IbanParserTests.cs
+++ b/test/IbanNet.Tests/IbanParserTests.cs
@@ -29,10 +29,10 @@ public class IbanParserTests
         [InlineData("", typeof(IbanFormatException))]
         [InlineData("AD12000120359100100", typeof(IbanFormatException))]
         [InlineData("Invalid", typeof(IbanFormatException))]
-        public void Given_invalid_value_when_parsing_it_should_throw(string attemptedIbanValue, Type expectedExceptionType)
+        public void Given_invalid_value_when_parsing_it_should_throw(string? attemptedIbanValue, Type expectedExceptionType)
         {
             // Act
-            Action act = () => _sut.Parse(attemptedIbanValue);
+            Action act = () => _sut.Parse(attemptedIbanValue!);
 
             // Assert
             act.Should()
@@ -46,7 +46,7 @@ public class IbanParserTests
         [InlineData("")]
         [InlineData("AD12000120359100100")]
         [InlineData("Invalid")]
-        public void Given_invalid_value_when_trying_parsing_it_should_not_throw_and_return_false(string attemptedIbanValue)
+        public void Given_invalid_value_when_trying_parsing_it_should_not_throw_and_return_false(string? attemptedIbanValue)
         {
             // Act
             Func<bool> act = () => _sut.TryParse(attemptedIbanValue, out _);

--- a/test/IbanNet.Tests/IbanTests.cs
+++ b/test/IbanNet.Tests/IbanTests.cs
@@ -352,7 +352,7 @@ public class IbanTests
         [InlineData(null, "null")]  // JSON null.
         [InlineData(null, "\"\"")]  // Empty string
         [InlineData(null, "\" \"")] // String with whitespace
-        public void Given_a_valid_jsonString_when_deserializing_it_should_return_expected_iban(string expectedIban, string json)
+        public void Given_a_valid_jsonString_when_deserializing_it_should_return_expected_iban(string? expectedIban, string json)
         {
             // Act
             Iban? iban = System.Text.Json.JsonSerializer.Deserialize<Iban>(json);

--- a/test/IbanNet.Tests/IbanValidatorIntegrationTests.cs
+++ b/test/IbanNet.Tests/IbanValidatorIntegrationTests.cs
@@ -44,7 +44,7 @@ public class IbanValidatorIntegrationTests
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void When_validating_null_or_empty_value_should_not_validate(string iban)
+    public void When_validating_null_or_empty_value_should_not_validate(string? iban)
     {
         // Act
         ValidationResult actual = _sut.Validate(iban);

--- a/test/IbanNet.Tests/Internal/InputNormalizationTests.cs
+++ b/test/IbanNet.Tests/Internal/InputNormalizationTests.cs
@@ -9,7 +9,7 @@ public class InputNormalizationTests
     [InlineData("UNCHANGED", "UNCHANGED")]
     [InlineData("", "")]
     [InlineData(null, null)]
-    public void Given_string_when_normalizing_it_should_return_expected_value(string input, string expected)
+    public void Given_string_when_normalizing_it_should_return_expected_value(string? input, string? expected)
     {
         // Act
         string? actual = InputNormalization.NormalizeOrNull(input);

--- a/test/IbanNet.Tests/Registry/IbanCountryTests.cs
+++ b/test/IbanNet.Tests/Registry/IbanCountryTests.cs
@@ -7,11 +7,10 @@ public class IbanCountryTests
     [InlineData("")]
     [InlineData("N")]
     [InlineData("NLD")]
-    public void When_country_code_is_of_invalid_length_should_throw(string twoLetterISORegionName)
+    public void When_country_code_is_of_invalid_length_should_throw(string? twoLetterISORegionName)
     {
         // Act
-        // ReSharper disable once ObjectCreationAsStatement
-        Func<IbanCountry> act = () => new IbanCountry(twoLetterISORegionName);
+        Func<IbanCountry> act = () => new IbanCountry(twoLetterISORegionName!);
 
         // Assert
         act.Should()


### PR DESCRIPTION
Fixes xUnit1012: Null should not be used for type parameter 'nnn' of type 'string'. Use a non-null value, or convert the parameter to a nullable type.