### PR TITLE
QR IBAN validation is added as a standalone rule.

### DIFF
--- a/src/IbanNet/Extensions/SwissIbanExtensions.cs
+++ b/src/IbanNet/Extensions/SwissIbanExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+﻿using IbanNet.Validation.Rules;
 
 namespace IbanNet.Extensions;
 
@@ -35,12 +35,6 @@ public static class SwissIbanExtensions
             throw new ArgumentNullException(nameof(iban));
         }
 
-        if (iban.Country.TwoLetterISORegionName is "CH" or "LI"
-         && int.TryParse(iban.BankIdentifier, NumberStyles.None, NumberFormatInfo.InvariantInfo, out int iid))
-        {
-            return iid is >= 30000 and <= 31999;
-        }
-
-        return false;
+        return QrIbanRule.IsValid(iban.Country, iban.BankIdentifier ?? "");
     }
 }

--- a/src/IbanNet/Resources.Designer.cs
+++ b/src/IbanNet/Resources.Designer.cs
@@ -312,5 +312,14 @@ namespace IbanNet {
                 return ResourceManager.GetString("UnknownCountryCodeResult", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The IBAN is not a valid QR IBAN..
+        /// </summary>
+        internal static string InvalidQrIbanResult {
+            get {
+                return ResourceManager.GetString("InvalidQrIbanResult", resourceCulture);
+            }
+        }
     }
 }

--- a/src/IbanNet/Resources.resx
+++ b/src/IbanNet/Resources.resx
@@ -182,4 +182,7 @@
     <data name="ArgumentException_At_least_one_country_code_must_be_provided" xml:space="preserve">
         <value>At least one country code must be provided.</value>
     </data>
+    <data name="InvalidQrIbanResult" xml:space="preserve">
+        <value>The IBAN is not a valid QR IBAN.</value>
+    </data>
 </root>

--- a/src/IbanNet/Validation/Results/InvalidQrIbanResult.cs
+++ b/src/IbanNet/Validation/Results/InvalidQrIbanResult.cs
@@ -1,0 +1,15 @@
+﻿namespace IbanNet.Validation.Results;
+
+/// <summary>
+/// The result returned when the IBAN is not a valid QR IBAN.
+/// </summary>
+public class InvalidQrIbanResult : ErrorResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidQrIbanResult" /> class.
+    /// </summary>
+    public InvalidQrIbanResult()
+        : base(Resources.InvalidQrIbanResult)
+    {
+    }
+}

--- a/src/IbanNet/Validation/Rules/QrIbanRule.cs
+++ b/src/IbanNet/Validation/Rules/QrIbanRule.cs
@@ -1,0 +1,35 @@
+﻿using IbanNet.Validation.Results;
+
+namespace IbanNet.Validation.Rules;
+
+/// <summary>
+/// Asserts that the IBAN is a valid QR IBAN.
+/// </summary>
+internal sealed class QrIbanRule : IIbanValidationRule
+{
+    private static readonly string[] ValidCountries = ["CH", "LI"];
+
+    /// <inheritdoc />
+    public ValidationRuleResult Validate(ValidationRuleContext context)
+    {
+        string qrIban = context.Value;
+
+        if (qrIban.Length < 9)
+        {
+            return new InvalidQrIbanResult();
+        }
+
+        string countryIdentifier = qrIban.Substring(0, 2);
+        string qrIdentifier = qrIban.Substring(4, 5);
+
+        if (int.TryParse(qrIdentifier, out int id))
+        {
+            if (id >= 30000 && id <= 31999 && ValidCountries.Contains(countryIdentifier.ToUpperInvariant()))
+            {
+                return ValidationRuleResult.Success;
+            }
+        }
+
+        return new InvalidQrIbanResult();
+    }
+}

--- a/src/IbanNet/Validation/Rules/QrIbanRule.cs
+++ b/src/IbanNet/Validation/Rules/QrIbanRule.cs
@@ -7,7 +7,7 @@ namespace IbanNet.Validation.Rules;
 /// <summary>
 /// Asserts that the IBAN is a valid QR IBAN.
 /// </summary>
-internal sealed class QrIbanRule : IIbanValidationRule
+public sealed class QrIbanRule : IIbanValidationRule
 {
     /// <inheritdoc />
     public ValidationRuleResult Validate(ValidationRuleContext context)

--- a/src/IbanNet/Validation/Rules/QrIbanRule.cs
+++ b/src/IbanNet/Validation/Rules/QrIbanRule.cs
@@ -1,4 +1,5 @@
-﻿using IbanNet.Extensions;
+﻿using System.Globalization;
+using IbanNet.Registry;
 using IbanNet.Validation.Results;
 
 namespace IbanNet.Validation.Rules;
@@ -11,11 +12,19 @@ internal sealed class QrIbanRule : IIbanValidationRule
     /// <inheritdoc />
     public ValidationRuleResult Validate(ValidationRuleContext context)
     {
-        if (Iban.TryParse(context.Value, out Iban? iban) && SwissIbanExtensions.IsQrIban(iban))
+        IbanCountry? country = context.Country;
+        if (country != null && IsValid(country, context.Value.Substring(country.Bank.Position, country.Bank.Length)))
         {
             return ValidationRuleResult.Success;
         }
 
         return new InvalidQrIbanResult();
+    }
+
+    internal static bool IsValid(IbanCountry country, string iidStr)
+    {
+        return country.TwoLetterISORegionName is "CH" or "LI"
+           && int.TryParse(iidStr, NumberStyles.None, NumberFormatInfo.InvariantInfo, out int iid)
+           && iid is >= 30000 and <= 31999;
     }
 }

--- a/src/IbanNet/Validation/Rules/QrIbanRule.cs
+++ b/src/IbanNet/Validation/Rules/QrIbanRule.cs
@@ -1,4 +1,5 @@
-﻿using IbanNet.Validation.Results;
+﻿using IbanNet.Extensions;
+using IbanNet.Validation.Results;
 
 namespace IbanNet.Validation.Rules;
 
@@ -7,27 +8,12 @@ namespace IbanNet.Validation.Rules;
 /// </summary>
 internal sealed class QrIbanRule : IIbanValidationRule
 {
-    private static readonly string[] ValidCountries = ["CH", "LI"];
-
     /// <inheritdoc />
     public ValidationRuleResult Validate(ValidationRuleContext context)
     {
-        string qrIban = context.Value;
-
-        if (qrIban.Length < 9)
+        if (Iban.TryParse(context.Value, out Iban? iban) && SwissIbanExtensions.IsQrIban(iban))
         {
-            return new InvalidQrIbanResult();
-        }
-
-        string countryIdentifier = qrIban.Substring(0, 2);
-        string qrIdentifier = qrIban.Substring(4, 5);
-
-        if (int.TryParse(qrIdentifier, out int id))
-        {
-            if (id >= 30000 && id <= 31999 && ValidCountries.Contains(countryIdentifier.ToUpperInvariant()))
-            {
-                return ValidationRuleResult.Success;
-            }
+            return ValidationRuleResult.Success;
         }
 
         return new InvalidQrIbanResult();

--- a/test/IbanNet.Tests/Validation/Rules/IsValidQrIbanRuleTests.cs
+++ b/test/IbanNet.Tests/Validation/Rules/IsValidQrIbanRuleTests.cs
@@ -1,0 +1,40 @@
+﻿using IbanNet.Validation.Results;
+
+namespace IbanNet.Validation.Rules;
+
+public class IsValidQrIbanRuleTests
+{
+    private readonly QrIbanRule _sut;
+
+    public IsValidQrIbanRuleTests()
+    {
+        _sut = new QrIbanRule();
+    }
+
+    [InlineData("DE89370400440532013000")]
+    [InlineData("FR1420041010050500013M02606")]
+    [InlineData("CH93007620116238529579")]
+    [InlineData("DE893704004053201300")]
+    [InlineData("DE19370400440532013000")]
+    [InlineData("DE193%0400440532013000")]
+    [InlineData("DE193A0400440532013000")]
+    [InlineData("LI21088100002324013AA")]
+    [InlineData("LI7830X74502999200012")]
+    [Theory]
+    public void Given_invalid_values_it_should_return_success(string iban)
+    {
+        ValidationRuleResult actual = _sut.Validate(new ValidationRuleContext(iban));
+
+        actual.Should().BeOfType<InvalidQrIbanResult>();
+    }
+
+    [InlineData("LI7830174502999200012")]
+    [InlineData("CH4431999123000889012")]
+    [Theory]
+    public void Given_valid_values_it_should_return_success(string iban)
+    {
+        ValidationRuleResult actual = _sut.Validate(new ValidationRuleContext(iban));
+
+        actual.Should().Be(ValidationRuleResult.Success);
+    }
+}

--- a/test/IbanNet.Tests/Validation/Rules/IsValidQrIbanRuleTests.cs
+++ b/test/IbanNet.Tests/Validation/Rules/IsValidQrIbanRuleTests.cs
@@ -1,4 +1,5 @@
 ﻿using IbanNet.Validation.Results;
+using IbanNet.Registry;
 
 namespace IbanNet.Validation.Rules;
 
@@ -11,8 +12,6 @@ public class IsValidQrIbanRuleTests
         _sut = new QrIbanRule();
     }
 
-    [InlineData("")]
-    [InlineData(" ")]
     [InlineData("DE89370400440532013000")]
     [InlineData("FR1420041010050500013M02606")]
     [InlineData("CH93007620116238529579")]
@@ -22,21 +21,21 @@ public class IsValidQrIbanRuleTests
     [InlineData("DE193A0400440532013000")]
     [InlineData("LI21088100002324013AA")]
     [InlineData("LI7830X74502999200012")]
+    [InlineData("CH44 3199 9123 0008 8901 2")]
     [Theory]
     public void Given_invalid_values_it_should_return_success(string iban)
     {
-        ValidationRuleResult actual = _sut.Validate(new ValidationRuleContext(iban));
+        ValidationRuleResult actual = _sut.Validate(new ValidationRuleContext(iban, IbanRegistry.Default[iban.Substring(0, 2)]));
 
         actual.Should().BeOfType<InvalidQrIbanResult>();
     }
 
     [InlineData("LI7830174502999200012")]
     [InlineData("CH4431999123000889012")]
-    [InlineData("CH44 3199 9123 0008 8901 2")]
     [Theory]
     public void Given_valid_values_it_should_return_success(string iban)
     {
-        ValidationRuleResult actual = _sut.Validate(new ValidationRuleContext(iban));
+        ValidationRuleResult actual = _sut.Validate(new ValidationRuleContext(iban, IbanRegistry.Default[iban.Substring(0, 2)]));
 
         actual.Should().Be(ValidationRuleResult.Success);
     }

--- a/test/IbanNet.Tests/Validation/Rules/IsValidQrIbanRuleTests.cs
+++ b/test/IbanNet.Tests/Validation/Rules/IsValidQrIbanRuleTests.cs
@@ -11,6 +11,8 @@ public class IsValidQrIbanRuleTests
         _sut = new QrIbanRule();
     }
 
+    [InlineData("")]
+    [InlineData(" ")]
     [InlineData("DE89370400440532013000")]
     [InlineData("FR1420041010050500013M02606")]
     [InlineData("CH93007620116238529579")]
@@ -30,6 +32,7 @@ public class IsValidQrIbanRuleTests
 
     [InlineData("LI7830174502999200012")]
     [InlineData("CH4431999123000889012")]
+    [InlineData("CH44 3199 9123 0008 8901 2")]
     [Theory]
     public void Given_valid_values_it_should_return_success(string iban)
     {


### PR DESCRIPTION
QR IBAN validation is added as a standalone rule. This rule is only valid for QR IBAN's and hence not part of the default ruleset.