### PR TITLE
chore: drop .NET Standard 1.6 support

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
-    <DefineConstants Condition="$(TargetFramework.StartsWith('netstandard1'))">$(DefineConstants);NETSTD_LEGACY</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/IbanNet.DataAnnotations/IbanNet.DataAnnotations.csproj
+++ b/src/IbanNet.DataAnnotations/IbanNet.DataAnnotations.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;netstandard1.6;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net472;net462</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/IbanNet/Builders/BankAccountBuilderException.cs
+++ b/src/IbanNet/Builders/BankAccountBuilderException.cs
@@ -3,9 +3,7 @@
 /// <summary>
 /// The exception that is thrown when building a bank account number fails.
 /// </summary>
-#if !NETSTD_LEGACY
 [Serializable]
-#endif
 public class BankAccountBuilderException : InvalidOperationException
 {
     /// <summary>
@@ -34,7 +32,6 @@ public class BankAccountBuilderException : InvalidOperationException
     {
     }
 
-#if !NETSTD_LEGACY
     /// <summary>
     /// Initializes a new instance of the <see cref="BankAccountBuilderException" /> with serialized data.
     /// </summary>
@@ -45,8 +42,10 @@ public class BankAccountBuilderException : InvalidOperationException
     [Obsolete(DiagnosticId = "SYSLIB0051")]
 #pragma warning restore CA1041
 #endif
-    protected BankAccountBuilderException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context)
+    protected BankAccountBuilderException
+    (
+        System.Runtime.Serialization.SerializationInfo info,
+        System.Runtime.Serialization.StreamingContext context) : base(info, context)
     {
     }
-#endif
 }

--- a/src/IbanNet/CheckDigits/Calculators/InvalidTokenException.cs
+++ b/src/IbanNet/CheckDigits/Calculators/InvalidTokenException.cs
@@ -5,9 +5,7 @@ namespace IbanNet.CheckDigits.Calculators;
 /// <summary>
 /// Exception that is thrown when an unexpected token/character is encountered while computing check digits.
 /// </summary>
-#if !NETSTD_LEGACY
-    [Serializable]
-#endif
+[Serializable]
 public class InvalidTokenException : InvalidOperationException
 {
     /// <summary>
@@ -51,19 +49,20 @@ public class InvalidTokenException : InvalidOperationException
     {
     }
 
-#if !NETSTD_LEGACY
-        /// <summary>
-        /// Initializes a new instance of the <see cref="InvalidTokenException" /> with serialized data.
-        /// </summary>
-        /// <param name="info">The object that holds the serialized data.</param>
-        /// <param name="context">The contextual information about the source or destination.</param>
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidTokenException" /> with serialized data.
+    /// </summary>
+    /// <param name="info">The object that holds the serialized data.</param>
+    /// <param name="context">The contextual information about the source or destination.</param>
 #if NET8_0_OR_GREATER
 #pragma warning disable CA1041
         [Obsolete(DiagnosticId = "SYSLIB0051")]
 #pragma warning restore CA1041
 #endif
-        protected InvalidTokenException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context)
-        {
-        }
-#endif
+    protected InvalidTokenException
+    (
+        System.Runtime.Serialization.SerializationInfo info,
+        System.Runtime.Serialization.StreamingContext context) : base(info, context)
+    {
+    }
 }

--- a/src/IbanNet/IbanFormatException.cs
+++ b/src/IbanNet/IbanFormatException.cs
@@ -3,9 +3,7 @@
 /// <summary>
 /// The exception that is thrown when the format of an IBAN is invalid.
 /// </summary>
-#if !NETSTD_LEGACY
 [Serializable]
-#endif
 public class IbanFormatException : FormatException
 {
     /// <summary>
@@ -50,7 +48,6 @@ public class IbanFormatException : FormatException
     /// </summary>
     public ValidationResult? Result { get; }
 
-#if !NETSTD_LEGACY
     /// <summary>
     /// Initializes a new instance of the <see cref="IbanFormatException" /> with serialized data.
     /// </summary>
@@ -61,9 +58,11 @@ public class IbanFormatException : FormatException
     [Obsolete(DiagnosticId = "SYSLIB0051")]
 #pragma warning restore CA1041
 #endif
-    protected IbanFormatException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context)
+    protected IbanFormatException
+    (
+        System.Runtime.Serialization.SerializationInfo info,
+        System.Runtime.Serialization.StreamingContext context) : base(info, context)
     {
         // Note: Result property info is lost since it is not serializable.
     }
-#endif
 }

--- a/src/IbanNet/IbanNet.csproj
+++ b/src/IbanNet/IbanNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;netstandard1.6;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net472;net462</TargetFrameworks>
     <AllowUnsafeBlocks Condition="!$(DefineConstants.Contains('USE_SPANS'))">true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);CA1052;CA1031</NoWarn>
   </PropertyGroup>
@@ -26,10 +26,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard1'))">
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IbanNet/Registry/IbanCountryCodeComparer.cs
+++ b/src/IbanNet/Registry/IbanCountryCodeComparer.cs
@@ -1,4 +1,4 @@
-﻿#if DEBUG && NETSTANDARD1_6 // Only used atm. by PS script, so exclude from all build configs except debug.
+﻿#if DEBUG && NETSTANDARD2_0 // Only used atm. by PS script, so exclude from all build configs except debug.
 using System.Diagnostics;
 
 namespace IbanNet.Registry;

--- a/src/IbanNet/Registry/Patterns/PatternException.cs
+++ b/src/IbanNet/Registry/Patterns/PatternException.cs
@@ -3,9 +3,7 @@
 /// <summary>
 /// The exception that is thrown when a pattern is invalid.
 /// </summary>
-#if !NETSTD_LEGACY
 [Serializable]
-#endif
 public class PatternException : FormatException
 {
     /// <summary>
@@ -34,7 +32,6 @@ public class PatternException : FormatException
     {
     }
 
-#if !NETSTD_LEGACY
     /// <summary>
     /// Initializes a new instance of the <see cref="PatternException" /> with serialized data.
     /// </summary>
@@ -45,8 +42,10 @@ public class PatternException : FormatException
     [Obsolete(DiagnosticId = "SYSLIB0051")]
 #pragma warning restore CA1041
 #endif
-    protected PatternException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context)
+    protected PatternException
+    (
+        System.Runtime.Serialization.SerializationInfo info,
+        System.Runtime.Serialization.StreamingContext context) : base(info, context)
     {
     }
-#endif
 }

--- a/src/IbanNet/Registry/Patterns/PatternToken.cs
+++ b/src/IbanNet/Registry/Patterns/PatternToken.cs
@@ -21,15 +21,6 @@ public sealed class PatternToken
         IsMatch = (ch, index) => index < value.Length && ch == value[index];
     }
 
-#if NETSTANDARD1_6
-    /// <summary>
-    /// Initializes a new instance of the pattern token.
-    /// </summary>
-    /// <param name="category">The ASCII category for the token.</param>
-    /// <param name="length">The length of the token.</param>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="length" /> is less than 1.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="category" /> is an invalid value.</exception>
-#else
     /// <summary>
     /// Initializes a new instance of the pattern token.
     /// </summary>
@@ -37,22 +28,11 @@ public sealed class PatternToken
     /// <param name="length">The length of the token.</param>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="length" /> is less than 1.</exception>
     /// <exception cref="InvalidEnumArgumentException">Thrown when <paramref name="category" /> is an invalid value.</exception>
-#endif
     public PatternToken(AsciiCategory category, int length)
         : this(category, length, length, nameof(length))
     {
     }
 
-#if NETSTANDARD1_6
-    /// <summary>
-    /// Initializes a new instance of the pattern token.
-    /// </summary>
-    /// <param name="category">The ASCII category for the token.</param>
-    /// <param name="minLength">The minimum length of the token.</param>
-    /// <param name="maxLength">The maximum length of the token.</param>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="minLength" /> or <paramref name="maxLength" /> is less than 1, or <paramref name="maxLength" /> is less than <paramref name="minLength" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="category" /> is an invalid value.</exception>
-#else
     /// <summary>
     /// Initializes a new instance of the pattern token.
     /// </summary>
@@ -61,7 +41,6 @@ public sealed class PatternToken
     /// <param name="maxLength">The maximum length of the token.</param>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="minLength" /> or <paramref name="maxLength" /> is less than 1, or <paramref name="maxLength" /> is less than <paramref name="minLength" />.</exception>
     /// <exception cref="InvalidEnumArgumentException">Thrown when <paramref name="category" /> is an invalid value.</exception>
-#endif
     public PatternToken(AsciiCategory category, int minLength, int maxLength)
         : this(category, minLength, maxLength, nameof(minLength))
     {
@@ -131,11 +110,7 @@ public sealed class PatternToken
     {
         if (!Enum.IsDefined(typeof(AsciiCategory), category))
         {
-#if NETSTANDARD1_6
-            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Enum_value_0_should_be_defined_in_the_1_enum, category, nameof(AsciiCategory)), nameof(category));
-#else
             throw new InvalidEnumArgumentException(nameof(category), (int)category, typeof(AsciiCategory));
-#endif
         }
 
         return category switch

--- a/src/IbanNet/Resources.Designer.cs
+++ b/src/IbanNet/Resources.Designer.cs
@@ -8,7 +8,6 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-using System.Reflection;
 namespace IbanNet {
     using System;
     
@@ -40,7 +39,7 @@ namespace IbanNet {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("IbanNet.Resources", typeof(Resources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("IbanNet.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -112,15 +111,6 @@ namespace IbanNet {
         internal static string CountryNotAcceptedResult_Bank_account_numbers_from_country_0_are_not_accepted {
             get {
                 return ResourceManager.GetString("CountryNotAcceptedResult_Bank_account_numbers_from_country_0_are_not_accepted", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Enum value &apos;{0}&apos; should be defined in the &apos;{1}&apos; enum..
-        /// </summary>
-        internal static string Enum_value_0_should_be_defined_in_the_1_enum {
-            get {
-                return ResourceManager.GetString("Enum_value_0_should_be_defined_in_the_1_enum", resourceCulture);
             }
         }
         
@@ -233,6 +223,15 @@ namespace IbanNet {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The IBAN is not a valid QR IBAN..
+        /// </summary>
+        internal static string InvalidQrIbanResult {
+            get {
+                return ResourceManager.GetString("InvalidQrIbanResult", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The pattern of the IBAN is incorrect..
         /// </summary>
         internal static string InvalidStructureResult {
@@ -310,15 +309,6 @@ namespace IbanNet {
         internal static string UnknownCountryCodeResult {
             get {
                 return ResourceManager.GetString("UnknownCountryCodeResult", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The IBAN is not a valid QR IBAN..
-        /// </summary>
-        internal static string InvalidQrIbanResult {
-            get {
-                return ResourceManager.GetString("InvalidQrIbanResult", resourceCulture);
             }
         }
     }

--- a/src/IbanNet/Resources.ca.resx
+++ b/src/IbanNet/Resources.ca.resx
@@ -167,9 +167,6 @@
     <data name="The_value_cannot_be_less_than_or_equal_to_0" xml:space="preserve">
         <value>El valor no pot ser inferior o igual a {0}.</value>
     </data>
-    <data name="Enum_value_0_should_be_defined_in_the_1_enum" xml:space="preserve">
-        <value>El valor de l'enum '{0}' hauria d'estar definit a l'enum '{1}'.</value>
-    </data>
     <data name="Exception_The_country_0_does_not_define_a_BBAN_pattern" xml:space="preserve">
         <value>El país '{0}' no defineix un patró BBAN.</value>
     </data>

--- a/src/IbanNet/Resources.de.resx
+++ b/src/IbanNet/Resources.de.resx
@@ -167,9 +167,6 @@
     <data name="The_value_cannot_be_less_than_or_equal_to_0" xml:space="preserve">
         <value>Der Wert darf nicht kleiner oder gleich {0} sein.</value>
     </data>
-    <data name="Enum_value_0_should_be_defined_in_the_1_enum" xml:space="preserve">
-        <value>Der Enum-Wert '{0}' sollte im Enum '{1}' definiert sein.</value>
-    </data>
     <data name="Exception_The_country_0_does_not_define_a_BBAN_pattern" xml:space="preserve">
         <value>Das Land '{0}' definiert kein BBAN-Muster.</value>
     </data>

--- a/src/IbanNet/Resources.nl.resx
+++ b/src/IbanNet/Resources.nl.resx
@@ -186,9 +186,6 @@
   <data name="The_value_cannot_be_less_than_or_equal_to_0" xml:space="preserve">
     <value>De waarde kan niet minder dan- of gelijk zijn aan {0}.</value>
   </data>
-  <data name="Enum_value_0_should_be_defined_in_the_1_enum" xml:space="preserve">
-    <value>Enum waarde '{0}' dient gedefinieerd te zijn in de '{1}' enum.</value>
-  </data>
   <data name="Exception_The_country_0_does_not_define_a_BBAN_pattern" xml:space="preserve">
     <value>Het land '{0}' heeft geen BBAN-patroon gedefinieerd.</value>
   </data>

--- a/src/IbanNet/Resources.resx
+++ b/src/IbanNet/Resources.resx
@@ -167,9 +167,6 @@
     <data name="The_value_cannot_be_less_than_or_equal_to_0" xml:space="preserve">
         <value>The value cannot be less than or equal to {0}.</value>
     </data>
-    <data name="Enum_value_0_should_be_defined_in_the_1_enum" xml:space="preserve">
-        <value>Enum value '{0}' should be defined in the '{1}' enum.</value>
-    </data>
     <data name="Exception_The_country_0_does_not_define_a_BBAN_pattern" xml:space="preserve">
         <value>The country '{0}' does not define a BBAN pattern.</value>
     </data>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
 
-    <DefineConstants Condition="'$(TargetFramework)'=='net48'">$(DefineConstants);NETSTD_LEGACY</DefineConstants>
     <MicrosoftNetTestSdk>17.10.0</MicrosoftNetTestSdk>
   </PropertyGroup>
 

--- a/test/IbanNet.Benchmark/IbanNet.Benchmark.csproj
+++ b/test/IbanNet.Benchmark/IbanNet.Benchmark.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net48;net472</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
     <Nullable>disable</Nullable>
     <DefineConstants Condition="'$(Configuration)'=='Release' And '$(ContinuousIntegrationBuild)'==''">$(DefineConstants);VALIDATOR_COMPARISONS</DefineConstants>

--- a/test/IbanNet.DataAnnotations.Tests/IbanNet.DataAnnotations.Tests.csproj
+++ b/test/IbanNet.DataAnnotations.Tests/IbanNet.DataAnnotations.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;net48;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;net472;net462</TargetFrameworks>
 
     <IsTestProject>true</IsTestProject>
 
@@ -15,7 +15,6 @@
     <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=net6.0" Condition="'$(TargetFramework)'=='net6.0'" />
     <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=netstandard2.1" Condition="'$(TargetFramework)'=='net5.0'" />
     <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=netstandard2.0" Condition="'$(TargetFramework)'=='netcoreapp3.1'" />
-    <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=netstandard1.6" Condition="'$(TargetFramework)'=='net48'" />
     <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=net472" Condition="'$(TargetFramework)'=='net472'" />
     <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=net462" Condition="'$(TargetFramework)'=='net462'" />
     <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.ServiceProvider\IbanNet.DependencyInjection.ServiceProvider.csproj" />

--- a/test/IbanNet.DataAnnotations.Tests/IbanNet.DataAnnotations.Tests.csproj
+++ b/test/IbanNet.DataAnnotations.Tests/IbanNet.DataAnnotations.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;net48;net472;net462</TargetFrameworks>
 
     <IsTestProject>true</IsTestProject>
 
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=net7.0" Condition="'$(TargetFramework)'=='net7.0'" />
     <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=net6.0" Condition="'$(TargetFramework)'=='net6.0'" />
     <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=netstandard2.1" Condition="'$(TargetFramework)'=='net5.0'" />
-    <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=netstandard2.0" Condition="'$(TargetFramework)'=='netcoreapp3.1'" />
+    <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=netstandard2.0" Condition="'$(TargetFramework)'=='net48'" />
     <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=net472" Condition="'$(TargetFramework)'=='net472'" />
     <ProjectReference Include="..\..\src\IbanNet.DataAnnotations\IbanNet.DataAnnotations.csproj" AdditionalProperties="TargetFramework=net462" Condition="'$(TargetFramework)'=='net462'" />
     <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.ServiceProvider\IbanNet.DependencyInjection.ServiceProvider.csproj" />
@@ -35,10 +35,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.10" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.18" />
   </ItemGroup>
 
 </Project>

--- a/test/IbanNet.DependencyInjection.Autofac.Tests/IbanNet.DependencyInjection.Autofac.Tests.csproj
+++ b/test/IbanNet.DependencyInjection.Autofac.Tests/IbanNet.DependencyInjection.Autofac.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;net48</TargetFrameworks>
 
     <IsTestProject>true</IsTestProject>
 
@@ -17,7 +17,7 @@
     <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.Autofac\IbanNet.DependencyInjection.Autofac.csproj" AdditionalProperties="TargetFramework=net7.0" Condition="'$(TargetFramework)'=='net7.0'" />
     <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.Autofac\IbanNet.DependencyInjection.Autofac.csproj" AdditionalProperties="TargetFramework=net6.0" Condition="'$(TargetFramework)'=='net6.0'" />
     <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.Autofac\IbanNet.DependencyInjection.Autofac.csproj" AdditionalProperties="TargetFramework=netstandard2.1" Condition="'$(TargetFramework)'=='net5.0'" />
-    <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.Autofac\IbanNet.DependencyInjection.Autofac.csproj" AdditionalProperties="TargetFramework=netstandard2.0" Condition="'$(TargetFramework)'=='netcoreapp3.1'" />
+    <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.Autofac\IbanNet.DependencyInjection.Autofac.csproj" AdditionalProperties="TargetFramework=netstandard2.0" Condition="'$(TargetFramework)'=='net48'" />
     <ProjectReference Include="..\TestHelpers\TestHelpers.csproj" />
   </ItemGroup>
 

--- a/test/IbanNet.DependencyInjection.ServiceProvider.Tests/IbanNet.DependencyInjection.ServiceProvider.Tests.csproj
+++ b/test/IbanNet.DependencyInjection.ServiceProvider.Tests/IbanNet.DependencyInjection.ServiceProvider.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;net48</TargetFrameworks>
 
     <IsTestProject>true</IsTestProject>
 
@@ -17,7 +17,7 @@
     <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.ServiceProvider\IbanNet.DependencyInjection.ServiceProvider.csproj" AdditionalProperties="TargetFramework=net7.0" Condition="'$(TargetFramework)'=='net7.0'" />
     <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.ServiceProvider\IbanNet.DependencyInjection.ServiceProvider.csproj" AdditionalProperties="TargetFramework=net6.0" Condition="'$(TargetFramework)'=='net6.0'" />
     <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.ServiceProvider\IbanNet.DependencyInjection.ServiceProvider.csproj" AdditionalProperties="TargetFramework=netstandard2.1" Condition="'$(TargetFramework)'=='net5.0'" />
-    <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.ServiceProvider\IbanNet.DependencyInjection.ServiceProvider.csproj" AdditionalProperties="TargetFramework=netstandard2.0" Condition="'$(TargetFramework)'=='netcoreapp3.1'" />
+    <ProjectReference Include="..\..\src\IbanNet.DependencyInjection.ServiceProvider\IbanNet.DependencyInjection.ServiceProvider.csproj" AdditionalProperties="TargetFramework=netstandard2.0" Condition="'$(TargetFramework)'=='net48'" />
     <ProjectReference Include="..\TestHelpers\TestHelpers.csproj" />
   </ItemGroup>
 

--- a/test/IbanNet.DependencyInjection.ServiceProvider.Tests/Specs/ShouldValidateOptionsRegistrySpec.cs
+++ b/test/IbanNet.DependencyInjection.ServiceProvider.Tests/Specs/ShouldValidateOptionsRegistrySpec.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP3_1_OR_GREATER
+﻿#if NETCOREAPP
 using IbanNet.DependencyInjection.ServiceProvider.Fixtures;
 using Microsoft.Extensions.Options;
 using TestHelpers.Specs;

--- a/test/IbanNet.FluentValidation.Tests/IbanNet.FluentValidation.Tests.csproj
+++ b/test/IbanNet.FluentValidation.Tests/IbanNet.FluentValidation.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;net48</TargetFrameworks>
 
     <IsTestProject>true</IsTestProject>
 
@@ -17,7 +17,7 @@
     <ProjectReference Include="..\..\src\IbanNet.FluentValidation\IbanNet.FluentValidation.csproj" AdditionalProperties="TargetFramework=net7.0" Condition="'$(TargetFramework)'=='net7.0'" />
     <ProjectReference Include="..\..\src\IbanNet.FluentValidation\IbanNet.FluentValidation.csproj" AdditionalProperties="TargetFramework=net6.0" Condition="'$(TargetFramework)'=='net6.0'" />
     <ProjectReference Include="..\..\src\IbanNet.FluentValidation\IbanNet.FluentValidation.csproj" AdditionalProperties="TargetFramework=netstandard2.1" Condition="'$(TargetFramework)'=='net5.0'" />
-    <ProjectReference Include="..\..\src\IbanNet.FluentValidation\IbanNet.FluentValidation.csproj" AdditionalProperties="TargetFramework=netstandard2.0" Condition="'$(TargetFramework)'=='netcoreapp3.1'" />
+    <ProjectReference Include="..\..\src\IbanNet.FluentValidation\IbanNet.FluentValidation.csproj" AdditionalProperties="TargetFramework=netstandard2.0" Condition="'$(TargetFramework)'=='net48'" />
     <ProjectReference Include="..\TestHelpers\TestHelpers.csproj" />
   </ItemGroup>
 

--- a/test/IbanNet.Tests/Builders/BankAccountBuilderExceptionTests.cs
+++ b/test/IbanNet.Tests/Builders/BankAccountBuilderExceptionTests.cs
@@ -5,7 +5,6 @@ namespace IbanNet.Builders;
 
 public class BankAccountBuilderExceptionTests : BaseExceptionTests<BankAccountBuilderException>
 {
-#if !NETSTD_LEGACY
     [Fact]
     public void Given_exception_with_parameters_it_should_serialize_and_deserialize()
     {
@@ -19,5 +18,4 @@ public class BankAccountBuilderExceptionTests : BaseExceptionTests<BankAccountBu
         // Assert
         actual.Should().BeEquivalentTo(exception);
     }
-#endif
 }

--- a/test/IbanNet.Tests/CheckDigits/Calculators/InvalidTokenExceptionTests.cs
+++ b/test/IbanNet.Tests/CheckDigits/Calculators/InvalidTokenExceptionTests.cs
@@ -5,7 +5,6 @@ namespace IbanNet.CheckDigits.Calculators;
 
 public class InvalidTokenExceptionTests : BaseExceptionTests<InvalidTokenException>
 {
-#if !NETSTD_LEGACY
     [Fact]
     public void Given_exception_with_parameters_it_should_serialize_and_deserialize()
     {
@@ -19,5 +18,4 @@ public class InvalidTokenExceptionTests : BaseExceptionTests<InvalidTokenExcepti
         // Assert
         actual.Should().BeEquivalentTo(exception);
     }
-#endif
 }

--- a/test/IbanNet.Tests/IbanFormatExceptionTests.cs
+++ b/test/IbanNet.Tests/IbanFormatExceptionTests.cs
@@ -21,7 +21,6 @@ public class IbanFormatExceptionTests : BaseExceptionTests<IbanFormatException>
         actual.Result.Should().Be(result);
     }
 
-#if !NETSTD_LEGACY
     [Fact]
     public void Given_exception_with_parameters_it_should_serialize_and_deserialize()
     {
@@ -51,5 +50,4 @@ public class IbanFormatExceptionTests : BaseExceptionTests<IbanFormatException>
             .BeEquivalentTo(exception, opts => opts.Excluding(ex => ex.Result));
         actualTyped.Result.Should().BeNull($"no serialization support is implemented for {nameof(ValidationResult)}");
     }
-#endif
 }

--- a/test/IbanNet.Tests/IbanNet.Tests.csproj
+++ b/test/IbanNet.Tests/IbanNet.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;net48;net472;net462</TargetFrameworks>
 
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);xUnit1026</NoWarn>
@@ -22,7 +22,7 @@
     <ProjectReference Include="..\..\src\IbanNet\IbanNet.csproj" AdditionalProperties="TargetFramework=net7.0" Condition="'$(TargetFramework)'=='net7.0'" />
     <ProjectReference Include="..\..\src\IbanNet\IbanNet.csproj" AdditionalProperties="TargetFramework=net6.0" Condition="'$(TargetFramework)'=='net6.0'" />
     <ProjectReference Include="..\..\src\IbanNet\IbanNet.csproj" AdditionalProperties="TargetFramework=netstandard2.1" Condition="'$(TargetFramework)'=='net5.0'" />
-    <ProjectReference Include="..\..\src\IbanNet\IbanNet.csproj" AdditionalProperties="TargetFramework=netstandard2.0" Condition="'$(TargetFramework)'=='netcoreapp3.1'" />
+    <ProjectReference Include="..\..\src\IbanNet\IbanNet.csproj" AdditionalProperties="TargetFramework=netstandard2.0" Condition="'$(TargetFramework)'=='net48'" />
     <ProjectReference Include="..\..\src\IbanNet\IbanNet.csproj" AdditionalProperties="TargetFramework=net472" Condition="'$(TargetFramework)'=='net472'" />
     <ProjectReference Include="..\..\src\IbanNet\IbanNet.csproj" AdditionalProperties="TargetFramework=net462" Condition="'$(TargetFramework)'=='net462'" />
     <ProjectReference Include="..\TestHelpers\TestHelpers.csproj" />

--- a/test/IbanNet.Tests/IbanNet.Tests.csproj
+++ b/test/IbanNet.Tests/IbanNet.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;net48;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;net472;net462</TargetFrameworks>
 
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);xUnit1026</NoWarn>
@@ -23,7 +23,6 @@
     <ProjectReference Include="..\..\src\IbanNet\IbanNet.csproj" AdditionalProperties="TargetFramework=net6.0" Condition="'$(TargetFramework)'=='net6.0'" />
     <ProjectReference Include="..\..\src\IbanNet\IbanNet.csproj" AdditionalProperties="TargetFramework=netstandard2.1" Condition="'$(TargetFramework)'=='net5.0'" />
     <ProjectReference Include="..\..\src\IbanNet\IbanNet.csproj" AdditionalProperties="TargetFramework=netstandard2.0" Condition="'$(TargetFramework)'=='netcoreapp3.1'" />
-    <ProjectReference Include="..\..\src\IbanNet\IbanNet.csproj" AdditionalProperties="TargetFramework=netstandard1.6" Condition="'$(TargetFramework)'=='net48'" />
     <ProjectReference Include="..\..\src\IbanNet\IbanNet.csproj" AdditionalProperties="TargetFramework=net472" Condition="'$(TargetFramework)'=='net472'" />
     <ProjectReference Include="..\..\src\IbanNet\IbanNet.csproj" AdditionalProperties="TargetFramework=net462" Condition="'$(TargetFramework)'=='net462'" />
     <ProjectReference Include="..\TestHelpers\TestHelpers.csproj" />

--- a/test/IbanNet.Tests/Registry/Patterns/PatternExceptionTests.cs
+++ b/test/IbanNet.Tests/Registry/Patterns/PatternExceptionTests.cs
@@ -5,7 +5,6 @@ namespace IbanNet.Registry.Patterns;
 
 public class PatternExceptionTests : BaseExceptionTests<PatternException>
 {
-#if !NETSTD_LEGACY
     [Fact]
     public void Given_validation_result_it_should_serialize_and_deserialize_and_ignore_result()
     {
@@ -19,5 +18,4 @@ public class PatternExceptionTests : BaseExceptionTests<PatternException>
         // Assert
         actual.Should().BeEquivalentTo(exception);
     }
-#endif
 }

--- a/test/IbanNet.Tests/Registry/Patterns/PatternTokenTests.cs
+++ b/test/IbanNet.Tests/Registry/Patterns/PatternTokenTests.cs
@@ -60,12 +60,7 @@ public class PatternTokenTests
 
         // Assert
         act.Should()
-#if NETSTD_LEGACY
-            .Throw<ArgumentException>()
-            .WithMessage(string.Format(Resources.Enum_value_0_should_be_defined_in_the_1_enum, category, nameof(AsciiCategory)) + "*")
-#else
             .Throw<InvalidEnumArgumentException>()
-#endif
             .WithParameterName(nameof(category));
     }
 


### PR DESCRIPTION
After a long time, but for maintainability sake, I have decided to drop .NET Standard 1.6 as a target framework for the packages:

- IbanNet 
- IbanNet.DataAnnotations

.NET Standard 2.x remains available to reference IbanNet in .NET (Framework) projects.
