### PR TITLE
ci: attempt to fix random AppDomain unloads in CI on macos/mono

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,7 +124,7 @@ jobs:
           name: build
 
       # Run all tests
-      - run: dotnet test --no-restore --no-build -c Release
+      - run: dotnet test --no-restore --no-build -c Release -- xUnit.AppDomain=denied
 
   pack:
     needs:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -83,6 +83,6 @@ jobs:
         run: |
           dotnet sonarscanner begin /k:"$SONAR_PROJECT_KEY" /o:"$SONAR_ORG_KEY" /d:sonar.host.url=https://sonarcloud.io /d:sonar.token="$SONAR_TOKEN" /d:sonar.cs.opencover.reportsPaths="**/*opencover.xml" $SONAR_PR_ARGS
 
-          dotnet test -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByFile="test/**/*.cs"
+          dotnet test -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByFile="test/**/*.cs" -- xUnit.AppDomain=denied
 
           dotnet sonarscanner end /d:sonar.token="$SONAR_TOKEN"


### PR DESCRIPTION
Disables xunit's AppDomain logic. Hopefully this resolves the random CI failures.