### PR TITLE
chore: make SwiftPattern fully internal, instead of public in DEBUG.

### DIFF
--- a/src/IbanNet.CodeGen/IbanNet.CodeGen.csproj
+++ b/src/IbanNet.CodeGen/IbanNet.CodeGen.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="CsvHelper" Version="30.0.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\IbanNet\IbanNet.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/IbanNet.CodeGen/Swift/SwiftCsvRecord.cs
+++ b/src/IbanNet.CodeGen/Swift/SwiftCsvRecord.cs
@@ -1,6 +1,8 @@
 ﻿using System.Globalization;
 using CsvHelper.Configuration.Attributes;
 using IbanNet.CodeGen.Swift.Converters;
+using IbanNet.Registry.Patterns;
+using IbanNet.Registry.Swift;
 
 namespace IbanNet.CodeGen.Swift;
 
@@ -77,6 +79,8 @@ public record IbanCsvData
 {
     [Name("IBAN structure")]
     public string Pattern { get; set; } = default!;
+
+    public Pattern SwiftPattern => new SwiftPattern(Pattern);
 
     [Name("IBAN length")]
     public int Length { get; set; }

--- a/src/IbanNet/Properties/AssemblyInfoAttributes.cs
+++ b/src/IbanNet/Properties/AssemblyInfoAttributes.cs
@@ -3,5 +3,8 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("IbanNet.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+#if DEBUG
+[assembly: InternalsVisibleTo("IbanNet.CodeGen")]
+#endif
 [assembly: NeutralResourcesLanguage("en")]
 [assembly: CLSCompliant(true)]

--- a/src/IbanNet/Registry/Swift/SwiftPattern.cs
+++ b/src/IbanNet/Registry/Swift/SwiftPattern.cs
@@ -3,12 +3,7 @@
 namespace IbanNet.Registry.Swift;
 
 /// <inheritdoc />
-#if DEBUG
-public
-#else
-internal
-#endif
-    class SwiftPattern : Pattern
+internal class SwiftPattern : Pattern
 {
     private static readonly SwiftPatternTokenizer Tokenizer = new();
     private string? _pattern;

--- a/src/IbanNet/Registry/Swift/SwiftRegistryProvider.tt
+++ b/src/IbanNet/Registry/Swift/SwiftRegistryProvider.tt
@@ -152,7 +152,7 @@ public class SwiftRegistryProvider : IIbanRegistryProvider
 <#
     foreach (var record in records)
     {
-        var pattern = new SwiftPattern(record.Iban.Pattern);
+        var pattern = record.Iban.SwiftPattern;
 #>
 
         [GeneratedCode("SwiftRegistryProviderT4", "1.1-<#= registryReleaseVersion #>")]


### PR DESCRIPTION
Make `SwiftPattern` fully internal, instead of public in `DEBUG`. This way, the API surface of IbanNet is consistent in DEBUG/RELEASE.

Instead, expose the parsed pattern via the import record/DTO and allow CodeGen to have access to IbanNet internals.