### PR TITLE
fix(CA2235): mark IbanFormatException.Result (backing field) as non-serializable

### DIFF
--- a/src/IbanNet/IbanFormatException.cs
+++ b/src/IbanNet/IbanFormatException.cs
@@ -6,6 +6,9 @@
 [Serializable]
 public class IbanFormatException : FormatException
 {
+    [NonSerialized]
+    private readonly ValidationResult? _result;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="IbanFormatException" />.
     /// </summary>
@@ -40,13 +43,16 @@ public class IbanFormatException : FormatException
     public IbanFormatException(string message, ValidationResult validationResult)
         : this(message)
     {
-        Result = validationResult;
+        _result = validationResult;
     }
 
     /// <summary>
     /// Gets the validation result.
     /// </summary>
-    public ValidationResult? Result { get; }
+    public ValidationResult? Result
+    {
+        get => _result;
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="IbanFormatException" /> with serialized data.


### PR DESCRIPTION
This satisfies CA2235 code warning. `ValidationResult` was never intended to be serializable.