### PR TITLE
ci(sonar): disable JRE provisioning

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -79,7 +79,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          dotnet sonarscanner begin /k:"$SONAR_PROJECT_KEY" /o:"$SONAR_ORG_KEY" /d:sonar.host.url=https://sonarcloud.io /d:sonar.token="$SONAR_TOKEN" /d:sonar.cs.opencover.reportsPaths="**/*opencover.xml" $SONAR_PR_ARGS
+          dotnet sonarscanner begin /k:"$SONAR_PROJECT_KEY" /o:"$SONAR_ORG_KEY" /d:sonar.host.url=https://sonarcloud.io /d:sonar.token="$SONAR_TOKEN" /d:sonar.cs.opencover.reportsPaths="**/*opencover.xml" /d:sonar.scanner.skipJreProvisioning=true $SONAR_PR_ARGS
 
           dotnet test -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByFile="test/**/*.cs" /p:VerifyPublicApi=false -- xUnit.AppDomain=denied
 


### PR DESCRIPTION
Java is already being setup via an action, so this is unnecessary overhead. JRE provisioning was added somewhere last year.

> Note: this change only becomes effective after merge, since the sonarcloud workflow runs actions from `main` branch as a security measure.

Log output before change:

```
Preparing working directories...
13:05:44.882  Updating build integration targets...
13:05:46.687  Using SonarCloud.
13:05:47.094  The JRE provisioning is a time consuming operation.
JRE provisioned: OpenJDK17U-jre_x64_linux_hotspot_17.0.11_9.tar.gz.
If you already have a compatible java version installed, please add either the parameter "/d:sonar.scanner.skipJreProvisioning=true" or "/d:sonar.scanner.javaExePath=<PATH>".
```