### PR TITLE
fix(S7637): use full commit SHA hash for `gittools/actions/**` dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,12 +35,12 @@ jobs:
           fetch-tags: true
 
       - name: Install GitVersion ${{ env.GITVERSION }}
-        uses: gittools/actions/gitversion/setup@v3.1.1
+        uses: gittools/actions/gitversion/setup@26a89e5dd4fa9ba66a853e04706ba52755ca4057 #v3.1.1
         with:
           versionSpec: ${{ env.GITVERSION }}
 
       - name: Determine version
-        uses: gittools/actions/gitversion/execute@v3.1.1
+        uses: gittools/actions/gitversion/execute@26a89e5dd4fa9ba66a853e04706ba52755ca4057 #v3.1.1
         id: gitversion
         with:
           useConfigFile: true


### PR DESCRIPTION
Fixes low CI security vulnerability:
https://sonarcloud.io/project/security_hotspots?id=skwasjer_IbanNet&hotspots=AZjBkvRwxdLhZo183dNu
https://sonarcloud.io/project/security_hotspots?id=skwasjer_IbanNet&hotspots=AZjBkvRwxdLhZo183dNv

GitTools actions are considered an 'untrusted' source. While I could modify the Sonar quality profile to allow that GitHub repo, I rather go the conservative route.
