### PR TITLE
fix(wikipedia): T4 loader code fails because a User-Agent header is now required.

### DIFF
--- a/src/IbanNet.CodeGen/Wikipedia/Loader.cs
+++ b/src/IbanNet.CodeGen/Wikipedia/Loader.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+﻿using System.Net.Http;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using HtmlAgilityPack;
@@ -14,11 +14,14 @@ public static class Loader
 #pragma warning disable S1075
         var uri = new Uri("https://en.wikipedia.org/w/api.php?format=json&action=parse&page=International_Bank_Account_Number&section=16", UriKind.Absolute);
 #pragma warning restore S1075
-        HttpWebRequest req = WebRequest.CreateHttp(uri);
-        using WebResponse response = req.GetResponse();
-        using var ms = new MemoryStream();
-        response.GetResponseStream()!.CopyTo(ms);
-        byte[] buffer = ms.ToArray();
+
+        using var httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.TryAddWithoutValidation(
+            "User-Agent",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
+        );
+        using HttpResponseMessage response = httpClient.GetAsync(uri).GetAwaiter().GetResult();
+        byte[] buffer = response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult();
 
         WikiResponse? wikiResponse = JsonSerializer.Deserialize<WikiResponse>(buffer, JsonSerializerOptions);
         if (wikiResponse is null)

--- a/src/IbanNet.CodeGen/Wikipedia/wiki.http
+++ b/src/IbanNet.CodeGen/Wikipedia/wiki.http
@@ -1,0 +1,7 @@
+﻿GET https://en.wikipedia.org/w/api.php?format=json&action=parse&page=International_Bank_Account_Number&section=16
+User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36
+
+###
+
+GET https://en.wikipedia.org/api/rest_v1/page/html/International_Bank_Account_Number
+User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36

--- a/src/IbanNet/Registry/Wikipedia/WikipediaRegistryProvider.cs
+++ b/src/IbanNet/Registry/Wikipedia/WikipediaRegistryProvider.cs
@@ -12,10 +12,10 @@ namespace IbanNet.Registry.Wikipedia;
 /// <para>
 /// Generated from: https://en.wikipedia.org/wiki/International_Bank_Account_Number
 /// Page ID: 15253
-/// Rev ID: 1249179146
+/// Rev ID: 1309493843
 /// </para>
 /// </remarks>
-[GeneratedCode("WikiRegistryProviderT4", "1.15253-1249179146")]
+[GeneratedCode("WikiRegistryProviderT4", "1.15253-1309493843")]
 public class WikipediaRegistryProvider : IIbanRegistryProvider
 {
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]


### PR DESCRIPTION
We're not really using/hitting this endpoint very much (nor automatically). It is only hit once every few months when I manually trigger an update. So I don't believe it is warranted to register a custom UA.

Took this opportunity to replace the old `WebRequest` with `HttpClient` (although I have to use `GetAwaiter()` :| ).