### PR TITLE
perf!: change ValidationRuleContext to readonly struct

### DIFF
--- a/src/IbanNet/IbanValidator.cs
+++ b/src/IbanNet/IbanValidator.cs
@@ -105,7 +105,12 @@ public sealed class IbanValidator : IIbanValidator
         {
             try
             {
-                error = rule.Validate(context) as ErrorResult;
+                ValidationRuleResult result = rule.Validate(context);
+                error = result as ErrorResult;
+                if (result is CountryResolvedResult cr)
+                {
+                    context = context with { Country = cr.Country };
+                }
             }
             catch (Exception ex)
             {

--- a/src/IbanNet/Validation/Results/CountryResolvedResult.cs
+++ b/src/IbanNet/Validation/Results/CountryResolvedResult.cs
@@ -1,0 +1,8 @@
+﻿using IbanNet.Registry;
+
+namespace IbanNet.Validation.Results;
+
+internal sealed class CountryResolvedResult(IbanCountry country) : ValidationRuleResult
+{
+    public IbanCountry Country { get; } = country;
+}

--- a/src/IbanNet/Validation/Rules/IsValidCountryCodeRule.cs
+++ b/src/IbanNet/Validation/Rules/IsValidCountryCodeRule.cs
@@ -24,8 +24,7 @@ internal sealed class IsValidCountryCodeRule : IIbanValidationRule
             return new UnknownCountryCodeResult();
         }
 
-        context.Country = country;
-        return ValidationRuleResult.Success;
+        return new CountryResolvedResult(country);
     }
 
 #if USE_SPANS

--- a/src/IbanNet/Validation/Rules/LimitCountryRule.cs
+++ b/src/IbanNet/Validation/Rules/LimitCountryRule.cs
@@ -41,11 +41,6 @@ public abstract class LimitCountryRule : IIbanValidationRule
     /// <inheritdoc />
     public ValidationRuleResult Validate(ValidationRuleContext context)
     {
-        if (context is null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
-
         bool matchesCountryCode = _countryCodes.Contains(context.Country!.TwoLetterISORegionName);
         return matchesCountryCode == _isAccepted
             ? ValidationRuleResult.Success

--- a/src/IbanNet/Validation/Rules/QrIbanRule.cs
+++ b/src/IbanNet/Validation/Rules/QrIbanRule.cs
@@ -12,11 +12,6 @@ public sealed class QrIbanRule : IIbanValidationRule
     /// <inheritdoc />
     public ValidationRuleResult Validate(ValidationRuleContext context)
     {
-        if (context is null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
-
         IbanCountry? country = context.Country;
         if (country != null && IsValid(country, context.Value.Substring(country.Bank.Position, country.Bank.Length)))
         {

--- a/src/IbanNet/Validation/Rules/ValidationRuleContext.cs
+++ b/src/IbanNet/Validation/Rules/ValidationRuleContext.cs
@@ -5,7 +5,7 @@ namespace IbanNet.Validation.Rules;
 /// <summary>
 /// The validation context for a validation rule.
 /// </summary>
-public class ValidationRuleContext
+public readonly record struct ValidationRuleContext
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ValidationRuleContext" /> class.
@@ -35,5 +35,5 @@ public class ValidationRuleContext
     /// <summary>
     /// Gets the country specific format information that applies to the IBAN, if any.
     /// </summary>
-    public IbanCountry? Country { get; internal set; }
+    public IbanCountry? Country { get; internal init; }
 }

--- a/test/IbanNet.Benchmark/BenchmarkResults.md
+++ b/test/IbanNet.Benchmark/BenchmarkResults.md
@@ -1,6 +1,6 @@
 # IbanNet Benchmark Results
 
-## Performance for >= v5.16.0
+## Performance for >= v5.18.0
 
 A single validation:
 
@@ -14,11 +14,11 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
   Job-OWJQPM : .NET Framework 4.8.1 (4.8.9310.0), X64 RyuJIT VectorSize=256
 ```
 
-| Method   | Runtime            | Mean     | Error   | StdDev  | Ratio | Gen0   | Allocated | Alloc Ratio |
-|--------- |------------------- |---------:|--------:|--------:|------:|-------:|----------:|------------:|
-| Validate | .NET 8.0           | 177.3 ns | 1.38 ns | 1.15 ns |  1.00 | 0.0279 |     176 B |        1.00 |
-| Validate | .NET 6.0           | 224.4 ns | 0.29 ns | 0.26 ns |  1.27 | 0.0279 |     176 B |        1.00 |
-| Validate | .NET Framework 4.8 | 311.8 ns | 1.48 ns | 1.38 ns |  1.76 | 0.0277 |     177 B |        1.01 |
+| Method   | Runtime            | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|--------- |------------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
+| Validate | .NET 8.0           | 187.2 ns | 0.71 ns | 0.55 ns |  1.00 |    0.00 | 0.0267 |     168 B |        1.00 |
+| Validate | .NET 6.0           | 226.4 ns | 1.62 ns | 1.44 ns |  1.21 |    0.01 | 0.0267 |     168 B |        1.00 |
+| Validate | .NET Framework 4.8 | 312.1 ns | 3.51 ns | 3.29 ns |  1.67 |    0.02 | 0.0267 |     168 B |        1.00 |
 
 
 ### Bulk (10k) runs
@@ -32,12 +32,28 @@ This benchmark validates 10,000 IBANs in a loop. It demonstrates the cost of reu
 
 | Method    | Runtime            | Count | Mean     | Error     | StdDev    | Ratio | RatioSD | Gen0      | Allocated | Alloc Ratio |
 |---------- |------------------- |------ |---------:|----------:|----------:|------:|--------:|----------:|----------:|------------:|
-| Singleton | .NET 8.0           | 10000 | 2.692 ms | 0.0332 ms | 0.0277 ms |  1.00 |    0.01 |  281.2500 |    1.7 MB |        1.00 |
-| Singleton | .NET 6.0           | 10000 | 3.180 ms | 0.0087 ms | 0.0073 ms |  1.18 |    0.01 |  281.2500 |    1.7 MB |        1.00 |
-| Singleton | .NET Framework 4.8 | 10000 | 4.048 ms | 0.0808 ms | 0.0865 ms |  1.50 |    0.03 |  281.2500 |   1.71 MB |        1.00 |
-| Transient | .NET 8.0           | 10000 | 5.217 ms | 0.0720 ms | 0.0739 ms |  1.94 |    0.03 | 1195.3125 |    7.2 MB |        4.23 |
-| Transient | .NET 6.0           | 10000 | 5.807 ms | 0.0377 ms | 0.0353 ms |  2.16 |    0.02 | 1265.6250 |   7.58 MB |        4.45 |
-| Transient | .NET Framework 4.8 | 10000 | 6.985 ms | 0.0371 ms | 0.0310 ms |  2.60 |    0.03 | 1289.0625 |   7.75 MB |        4.55 |
+| Singleton | .NET 8.0           | 10000 | 2.865 ms | 0.0551 ms | 0.0613 ms |  1.00 |    0.03 |  269.5313 |   1.63 MB |        1.00 |
+| Singleton | .NET 6.0           | 10000 | 3.233 ms | 0.0405 ms | 0.0338 ms |  1.13 |    0.03 |  269.5313 |   1.63 MB |        1.00 |
+| Singleton | .NET Framework 4.8 | 10000 | 4.000 ms | 0.0177 ms | 0.0166 ms |  1.40 |    0.03 |  265.6250 |   1.63 MB |        1.00 |
+| Transient | .NET 8.0           | 10000 | 5.326 ms | 0.0197 ms | 0.0165 ms |  1.86 |    0.04 | 1187.5000 |   7.12 MB |        4.38 |
+| Transient | .NET 6.0           | 10000 | 5.847 ms | 0.0720 ms | 0.0601 ms |  2.04 |    0.05 | 1250.0000 |    7.5 MB |        4.61 |
+| Transient | .NET Framework 4.8 | 10000 | 7.360 ms | 0.1392 ms | 0.1368 ms |  2.57 |    0.07 | 1273.4375 |   7.68 MB |        4.72 |
+
+
+### Validation per provider
+
+Validating with `SwiftRegistryProvider` is faster and allocates less memory than the `WikipediaRegistryProvider`, because the pattern matcher is unrolled instead of depending on a more generic match implementation (using an iterator).
+
+| Method   | Runtime            | args      | Mean     | Error    | StdDev   | Median   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|--------- |------------------- |---------- |---------:|---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
+| Validate | .NET 8.0           | Swift     | 158.2 ns |  2.29 ns |  2.03 ns | 157.6 ns |  1.00 |    0.02 | 0.0253 |     160 B |        1.00 |
+| Validate | .NET 6.0           | Swift     | 188.6 ns |  0.57 ns |  0.48 ns | 188.5 ns |  1.19 |    0.01 | 0.0253 |     160 B |        1.00 |
+| Validate | .NET Framework 4.8 | Swift     | 280.4 ns |  2.00 ns |  1.56 ns | 280.4 ns |  1.77 |    0.02 | 0.0253 |     160 B |        1.00 |
+|          |                    |           |          |          |          |          |       |         |        |           |             |
+| Validate | .NET 8.0           | Wikipedia | 198.1 ns |  1.50 ns |  2.29 ns | 197.9 ns |  1.00 |    0.02 | 0.0253 |     160 B |        1.00 |
+| Validate | .NET 6.0           | Wikipedia | 240.5 ns |  1.26 ns |  1.18 ns | 241.0 ns |  1.21 |    0.02 | 0.0253 |     160 B |        1.00 |
+| Validate | .NET Framework 4.8 | Wikipedia | 378.6 ns | 16.23 ns | 44.71 ns | 354.1 ns |  1.91 |    0.23 | 0.0253 |     160 B |        1.00 |
+
 
 ### Initialize registry
 
@@ -52,6 +68,7 @@ The registry lazy loads definitions. This benchmark only measures the cost of th
 | Initialize | .NET 8.0           | Wikipedia | 27.49 ns | 0.540 ns | 0.479 ns | 27.23 ns |  1.00 |    0.02 | 0.0242 |     152 B |        1.00 |
 | Initialize | .NET 6.0           | Wikipedia | 27.81 ns | 0.482 ns | 0.428 ns | 27.80 ns |  1.01 |    0.02 | 0.0242 |     152 B |        1.00 |
 | Initialize | .NET Framework 4.8 | Wikipedia | 31.95 ns | 0.185 ns | 0.155 ns | 31.92 ns |  1.16 |    0.02 | 0.0255 |     160 B |        1.05 |
+
 
 ### Look up country in registry
 
@@ -77,20 +94,6 @@ The registry lazy loads definitions. This benchmark only measures the cost of th
 | Lookup | .NET 8.0           | Wikipedia, warm |      8.823 ns |   0.0639 ns |   0.0566 ns |  1.00 |    0.01 |      - |      - |         - |          NA |
 | Lookup | .NET 6.0           | Wikipedia, warm |     17.830 ns |   0.1659 ns |   0.1552 ns |  2.02 |    0.02 |      - |      - |         - |          NA |
 | Lookup | .NET Framework 4.8 | Wikipedia, warm |     46.609 ns |   0.7311 ns |   0.6481 ns |  5.28 |    0.08 |      - |      - |         - |          NA |
-
-### Validation per provider
-
-Validating with `SwiftRegistryProvider` is faster and allocates less memory than the `WikipediaRegistryProvider`, because the pattern matcher is unrolled instead of depending on a more generic match implementation (using an iterator).
-
-| Method   | Runtime            | args      | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
-|--------- |------------------- |---------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
-| Validate | .NET 8.0           | Swift     | 159.1 ns | 3.12 ns | 4.26 ns |  1.00 |    0.04 | 0.0267 |     168 B |        1.00 |
-| Validate | .NET 6.0           | Swift     | 194.3 ns | 3.80 ns | 4.66 ns |  1.22 |    0.04 | 0.0267 |     168 B |        1.00 |
-| Validate | .NET Framework 4.8 | Swift     | 279.6 ns | 2.11 ns | 1.64 ns |  1.76 |    0.05 | 0.0267 |     168 B |        1.00 |
-|          |                    |           |          |         |         |       |         |        |           |             |
-| Validate | .NET 8.0           | Wikipedia | 191.7 ns | 3.85 ns | 5.65 ns |  1.00 |    0.04 | 0.0267 |     168 B |        1.00 |
-| Validate | .NET 6.0           | Wikipedia | 238.6 ns | 3.09 ns | 2.58 ns |  1.25 |    0.04 | 0.0267 |     168 B |        1.00 |
-| Validate | .NET Framework 4.8 | Wikipedia | 360.2 ns | 5.56 ns | 4.64 ns |  1.88 |    0.06 | 0.0267 |     168 B |        1.00 |
 
 
 ### CLI

--- a/test/IbanNet.Tests/PublicApi/.NET_6.0.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_6.0.verified.txt
@@ -434,7 +434,7 @@ namespace IbanNet.Validation.Rules
     {
         public RejectCountryRule(System.Collections.Generic.IEnumerable<string> rejectedCountryCodes) { }
     }
-    public class ValidationRuleContext
+    public readonly struct ValidationRuleContext : System.IEquatable<IbanNet.Validation.Rules.ValidationRuleContext>
     {
         public ValidationRuleContext(string value) { }
         public ValidationRuleContext(string value, IbanNet.Registry.IbanCountry country) { }

--- a/test/IbanNet.Tests/PublicApi/.NET_8.0.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_8.0.verified.txt
@@ -438,7 +438,7 @@ namespace IbanNet.Validation.Rules
     {
         public RejectCountryRule(System.Collections.Generic.IEnumerable<string> rejectedCountryCodes) { }
     }
-    public class ValidationRuleContext
+    public readonly struct ValidationRuleContext : System.IEquatable<IbanNet.Validation.Rules.ValidationRuleContext>
     {
         public ValidationRuleContext(string value) { }
         public ValidationRuleContext(string value, IbanNet.Registry.IbanCountry country) { }

--- a/test/IbanNet.Tests/PublicApi/.NET_Framework_4.6.2.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Framework_4.6.2.verified.txt
@@ -423,7 +423,7 @@ namespace IbanNet.Validation.Rules
     {
         public RejectCountryRule(System.Collections.Generic.IEnumerable<string> rejectedCountryCodes) { }
     }
-    public class ValidationRuleContext
+    public readonly struct ValidationRuleContext : System.IEquatable<IbanNet.Validation.Rules.ValidationRuleContext>
     {
         public ValidationRuleContext(string value) { }
         public ValidationRuleContext(string value, IbanNet.Registry.IbanCountry country) { }

--- a/test/IbanNet.Tests/PublicApi/.NET_Framework_4.7.2.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Framework_4.7.2.verified.txt
@@ -423,7 +423,7 @@ namespace IbanNet.Validation.Rules
     {
         public RejectCountryRule(System.Collections.Generic.IEnumerable<string> rejectedCountryCodes) { }
     }
-    public class ValidationRuleContext
+    public readonly struct ValidationRuleContext : System.IEquatable<IbanNet.Validation.Rules.ValidationRuleContext>
     {
         public ValidationRuleContext(string value) { }
         public ValidationRuleContext(string value, IbanNet.Registry.IbanCountry country) { }

--- a/test/IbanNet.Tests/PublicApi/.NET_Standard_2.0_via_.NET_Framework_4.8.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Standard_2.0_via_.NET_Framework_4.8.verified.txt
@@ -423,7 +423,7 @@ namespace IbanNet.Validation.Rules
     {
         public RejectCountryRule(System.Collections.Generic.IEnumerable<string> rejectedCountryCodes) { }
     }
-    public class ValidationRuleContext
+    public readonly struct ValidationRuleContext : System.IEquatable<IbanNet.Validation.Rules.ValidationRuleContext>
     {
         public ValidationRuleContext(string value) { }
         public ValidationRuleContext(string value, IbanNet.Registry.IbanCountry country) { }

--- a/test/IbanNet.Tests/PublicApi/.NET_Standard_2.1_via_.NET_7.0.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Standard_2.1_via_.NET_7.0.verified.txt
@@ -434,7 +434,7 @@ namespace IbanNet.Validation.Rules
     {
         public RejectCountryRule(System.Collections.Generic.IEnumerable<string> rejectedCountryCodes) { }
     }
-    public class ValidationRuleContext
+    public readonly struct ValidationRuleContext : System.IEquatable<IbanNet.Validation.Rules.ValidationRuleContext>
     {
         public ValidationRuleContext(string value) { }
         public ValidationRuleContext(string value, IbanNet.Registry.IbanCountry country) { }

--- a/test/IbanNet.Tests/Validation/Rules/AcceptCountryRuleTests.cs
+++ b/test/IbanNet.Tests/Validation/Rules/AcceptCountryRuleTests.cs
@@ -67,19 +67,4 @@ public class AcceptCountryRuleTests
             .WithParameterName(nameof(acceptedCountryCodes))
             .Which.Should().BeOfType<ArgumentException>();
     }
-
-    [Fact]
-    public void Given_that_context_is_null_when_validating_it_should_throw()
-    {
-        var sut = new AcceptCountryRule(["DE", "FR"]);
-        ValidationRuleContext? context = null;
-
-        // Act
-        Func<ValidationRuleResult> act = () => sut.Validate(context!);
-
-        // Assert
-        act.Should()
-            .Throw<ArgumentNullException>()
-            .WithParameterName(nameof(context));
-    }
 }

--- a/test/IbanNet.Tests/Validation/Rules/IsValidCountryCodeRuleTests.cs
+++ b/test/IbanNet.Tests/Validation/Rules/IsValidCountryCodeRuleTests.cs
@@ -42,8 +42,10 @@ public class IsValidCountryCodeRuleTests
         ValidationRuleResult actual = sut.Validate(context);
 
         // Assert
-        actual.Should().Be(ValidationRuleResult.Success);
-        context.Country.Should().BeSameAs(country);
+        actual.Should()
+            .BeOfType<CountryResolvedResult>()
+            .Which.Country.Should()
+            .Be(country);
     }
 
     [Fact]

--- a/test/IbanNet.Tests/Validation/Rules/IsValidQrIbanRuleTests.cs
+++ b/test/IbanNet.Tests/Validation/Rules/IsValidQrIbanRuleTests.cs
@@ -47,18 +47,4 @@ public sealed class IsValidQrIbanRuleTests
         // Assert
         actual.Should().Be(ValidationRuleResult.Success);
     }
-
-    [Fact]
-    public void Given_that_context_is_null_when_validating_it_should_throw()
-    {
-        ValidationRuleContext? context = null;
-
-        // Act
-        Action act = () => _sut.Validate(context!);
-
-        // Assert
-        act.Should()
-            .Throw<ArgumentNullException>()
-            .WithParameterName(nameof(context));
-    }
 }

--- a/test/IbanNet.Tests/Validation/Rules/RejectCountryRuleTests.cs
+++ b/test/IbanNet.Tests/Validation/Rules/RejectCountryRuleTests.cs
@@ -67,19 +67,4 @@ public class RejectCountryRuleTests
             .WithParameterName(nameof(rejectedCountryCodes))
             .Which.Should().BeOfType<ArgumentException>();
     }
-
-    [Fact]
-    public void Given_that_context_is_null_when_validating_it_should_throw()
-    {
-        var sut = new RejectCountryRule(["DE", "FR"]);
-        ValidationRuleContext? context = null;
-
-        // Act
-        Func<ValidationRuleResult> act = () => sut.Validate(context!);
-
-        // Assert
-        act.Should()
-            .Throw<ArgumentNullException>()
-            .WithParameterName(nameof(context));
-    }
 }


### PR DESCRIPTION
- no longer need null-reference checks
- adds IEquatable<> which can help to make tests simpler
- reduces heap allocations slightly (but very small)

It is however a breaking change.