### PR TITLE
perf!: change ValidationResult to readonly struct

### DIFF
--- a/src/IbanNet/IbanParser.cs
+++ b/src/IbanNet/IbanParser.cs
@@ -46,16 +46,16 @@ public sealed class IbanParser : IIbanParser
             throw new ArgumentNullException(nameof(value));
         }
 
-        if (TryParse(value, out Iban? iban, out ValidationResult? validationResult, out Exception? exceptionThrown))
+        if (TryParse(value, out Iban? iban, out ValidationResult validationResult, out Exception? exceptionThrown))
         {
             return iban;
         }
 
-        string errorMessage = validationResult?.Error is null || string.IsNullOrEmpty(validationResult.Error.ErrorMessage)
+        string errorMessage = validationResult.Error is null || string.IsNullOrEmpty(validationResult.Error.ErrorMessage)
             ? string.Format(CultureInfo.CurrentCulture, Resources.IbanFormatException_The_value_0_is_not_a_valid_IBAN, value)
             : validationResult.Error.ErrorMessage;
 
-        if (validationResult is null || exceptionThrown is not null)
+        if (exceptionThrown is not null)
         {
             throw new IbanFormatException(errorMessage, exceptionThrown);
         }
@@ -76,7 +76,7 @@ public sealed class IbanParser : IIbanParser
         string? value,
 #endif
         [NotNullWhen(true)] out Iban? iban,
-        [MaybeNullWhen(false)] out ValidationResult? validationResult,
+        out ValidationResult validationResult,
         [MaybeNullWhen(false)] out Exception? exceptionThrown)
     {
         iban = null;
@@ -94,7 +94,7 @@ public sealed class IbanParser : IIbanParser
         }
         catch (Exception ex)
         {
-            validationResult = null;
+            validationResult = default;
             exceptionThrown = ex;
             return false;
         }

--- a/src/IbanNet/ValidationResult.cs
+++ b/src/IbanNet/ValidationResult.cs
@@ -6,12 +6,12 @@ namespace IbanNet;
 /// <summary>
 /// Represents the validator result.
 /// </summary>
-public sealed class ValidationResult
+public readonly record struct ValidationResult
 {
     /// <summary>
     /// Gets whether validation is successful.
     /// </summary>
-    public bool IsValid => Error is null;
+    public bool IsValid => Error is null && AttemptedValue is not null && Country is not null;
 
     /// <summary>
     /// Gets the IBAN value for which validation was attempted.

--- a/test/IbanNet.Benchmark/BenchmarkResults.md
+++ b/test/IbanNet.Benchmark/BenchmarkResults.md
@@ -16,9 +16,9 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
 
 | Method   | Runtime            | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
 |--------- |------------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
-| Validate | .NET 8.0           | 187.2 ns | 0.71 ns | 0.55 ns |  1.00 |    0.00 | 0.0267 |     168 B |        1.00 |
-| Validate | .NET 6.0           | 226.4 ns | 1.62 ns | 1.44 ns |  1.21 |    0.01 | 0.0267 |     168 B |        1.00 |
-| Validate | .NET Framework 4.8 | 312.1 ns | 3.51 ns | 3.29 ns |  1.67 |    0.02 | 0.0267 |     168 B |        1.00 |
+| Validate | .NET 8.0           | 183.4 ns | 1.12 ns | 0.87 ns |  1.00 |    0.01 | 0.0203 |     128 B |        1.00 |
+| Validate | .NET 6.0           | 222.0 ns | 0.93 ns | 0.77 ns |  1.21 |    0.01 | 0.0203 |     128 B |        1.00 |
+| Validate | .NET Framework 4.8 | 313.6 ns | 2.72 ns | 2.54 ns |  1.71 |    0.02 | 0.0200 |     128 B |        1.00 |
 
 
 ### Bulk (10k) runs
@@ -32,27 +32,27 @@ This benchmark validates 10,000 IBANs in a loop. It demonstrates the cost of reu
 
 | Method    | Runtime            | Count | Mean     | Error     | StdDev    | Ratio | RatioSD | Gen0      | Allocated | Alloc Ratio |
 |---------- |------------------- |------ |---------:|----------:|----------:|------:|--------:|----------:|----------:|------------:|
-| Singleton | .NET 8.0           | 10000 | 2.865 ms | 0.0551 ms | 0.0613 ms |  1.00 |    0.03 |  269.5313 |   1.63 MB |        1.00 |
-| Singleton | .NET 6.0           | 10000 | 3.233 ms | 0.0405 ms | 0.0338 ms |  1.13 |    0.03 |  269.5313 |   1.63 MB |        1.00 |
-| Singleton | .NET Framework 4.8 | 10000 | 4.000 ms | 0.0177 ms | 0.0166 ms |  1.40 |    0.03 |  265.6250 |   1.63 MB |        1.00 |
-| Transient | .NET 8.0           | 10000 | 5.326 ms | 0.0197 ms | 0.0165 ms |  1.86 |    0.04 | 1187.5000 |   7.12 MB |        4.38 |
-| Transient | .NET 6.0           | 10000 | 5.847 ms | 0.0720 ms | 0.0601 ms |  2.04 |    0.05 | 1250.0000 |    7.5 MB |        4.61 |
-| Transient | .NET Framework 4.8 | 10000 | 7.360 ms | 0.1392 ms | 0.1368 ms |  2.57 |    0.07 | 1273.4375 |   7.68 MB |        4.72 |
+| Singleton | .NET 8.0           | 10000 | 2.919 ms | 0.0289 ms | 0.0256 ms |  1.00 |    0.01 |  207.0313 |   1.24 MB |        1.00 |
+| Singleton | .NET 6.0           | 10000 | 3.225 ms | 0.0074 ms | 0.0066 ms |  1.10 |    0.01 |  207.0313 |   1.24 MB |        1.00 |
+| Singleton | .NET Framework 4.8 | 10000 | 4.075 ms | 0.0188 ms | 0.0176 ms |  1.40 |    0.01 |  203.1250 |   1.25 MB |        1.00 |
+| Transient | .NET 8.0           | 10000 | 5.352 ms | 0.0480 ms | 0.0401 ms |  1.83 |    0.02 | 1125.0000 |   6.74 MB |        5.41 |
+| Transient | .NET 6.0           | 10000 | 5.746 ms | 0.0296 ms | 0.0277 ms |  1.97 |    0.02 | 1187.5000 |   7.12 MB |        5.72 |
+| Transient | .NET Framework 4.8 | 10000 | 7.141 ms | 0.0462 ms | 0.0386 ms |  2.45 |    0.02 | 1210.9375 |   7.29 MB |        5.86 |
 
 
 ### Validation per provider
 
 Validating with `SwiftRegistryProvider` is faster and allocates less memory than the `WikipediaRegistryProvider`, because the pattern matcher is unrolled instead of depending on a more generic match implementation (using an iterator).
 
-| Method   | Runtime            | args      | Mean     | Error    | StdDev   | Median   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
-|--------- |------------------- |---------- |---------:|---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
-| Validate | .NET 8.0           | Swift     | 158.2 ns |  2.29 ns |  2.03 ns | 157.6 ns |  1.00 |    0.02 | 0.0253 |     160 B |        1.00 |
-| Validate | .NET 6.0           | Swift     | 188.6 ns |  0.57 ns |  0.48 ns | 188.5 ns |  1.19 |    0.01 | 0.0253 |     160 B |        1.00 |
-| Validate | .NET Framework 4.8 | Swift     | 280.4 ns |  2.00 ns |  1.56 ns | 280.4 ns |  1.77 |    0.02 | 0.0253 |     160 B |        1.00 |
-|          |                    |           |          |          |          |          |       |         |        |           |             |
-| Validate | .NET 8.0           | Wikipedia | 198.1 ns |  1.50 ns |  2.29 ns | 197.9 ns |  1.00 |    0.02 | 0.0253 |     160 B |        1.00 |
-| Validate | .NET 6.0           | Wikipedia | 240.5 ns |  1.26 ns |  1.18 ns | 241.0 ns |  1.21 |    0.02 | 0.0253 |     160 B |        1.00 |
-| Validate | .NET Framework 4.8 | Wikipedia | 378.6 ns | 16.23 ns | 44.71 ns | 354.1 ns |  1.91 |    0.23 | 0.0253 |     160 B |        1.00 |
+| Method   | Runtime            | args      | Mean     | Error   | StdDev   | Median   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|--------- |------------------- |---------- |---------:|--------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
+| Validate | .NET 8.0           | Swift     | 163.7 ns | 4.10 ns | 12.10 ns | 155.7 ns |  1.01 |    0.10 | 0.0191 |     120 B |        1.00 |
+| Validate | .NET 6.0           | Swift     | 185.7 ns | 0.63 ns |  0.59 ns | 185.7 ns |  1.14 |    0.08 | 0.0191 |     120 B |        1.00 |
+| Validate | .NET Framework 4.8 | Swift     | 280.7 ns | 1.40 ns |  1.24 ns | 281.3 ns |  1.72 |    0.12 | 0.0191 |     120 B |        1.00 |
+|          |                    |           |          |         |          |          |       |         |        |           |             |
+| Validate | .NET 8.0           | Wikipedia | 187.3 ns | 0.96 ns |  0.85 ns | 187.5 ns |  1.00 |    0.01 | 0.0191 |     120 B |        1.00 |
+| Validate | .NET 6.0           | Wikipedia | 234.5 ns | 0.85 ns |  0.79 ns | 234.7 ns |  1.25 |    0.01 | 0.0191 |     120 B |        1.00 |
+| Validate | .NET Framework 4.8 | Wikipedia | 363.1 ns | 2.28 ns |  2.13 ns | 363.3 ns |  1.94 |    0.01 | 0.0191 |     120 B |        1.00 |
 
 
 ### Initialize registry
@@ -79,22 +79,21 @@ The registry lazy loads definitions. This benchmark only measures the cost of th
 
 | Method | Runtime            | args            | Mean          | Error       | StdDev      | Ratio | RatioSD | Gen0   | Gen1   | Allocated | Alloc Ratio |
 |------- |------------------- |---------------- |--------------:|------------:|------------:|------:|--------:|-------:|-------:|----------:|------------:|
-| Lookup | .NET 6.0           | Swift, cold     | 11,709.171 ns | 129.0066 ns | 107.7263 ns |  0.71 |    0.01 | 2.3804 | 0.0763 |   15016 B |        0.59 |
-| Lookup | .NET Framework 4.8 | Swift, cold     | 13,716.381 ns |  21.4214 ns |  16.7245 ns |  0.83 |    0.01 | 2.3956 | 0.0916 |   15116 B |        0.60 |
-| Lookup | .NET 8.0           | Swift, cold     | 16,568.963 ns | 217.9237 ns | 203.8460 ns |  1.00 |    0.02 | 4.0283 | 0.1831 |   25336 B |        1.00 |
+| Lookup | .NET 6.0           | Swift, cold     | 12,163.234 ns | 232.7871 ns | 249.0796 ns |  0.72 |    0.02 | 2.3804 | 0.0763 |   15016 B |        0.59 |
+| Lookup | .NET Framework 4.8 | Swift, cold     | 14,373.741 ns | 278.3103 ns | 341.7900 ns |  0.85 |    0.03 | 2.3956 | 0.0916 |   15116 B |        0.60 |
+| Lookup | .NET 8.0           | Swift, cold     | 16,887.011 ns | 325.7609 ns | 375.1467 ns |  1.00 |    0.03 | 4.0283 | 0.1831 |   25336 B |        1.00 |
 |        |                    |                 |               |             |             |       |         |        |        |           |             |
-| Lookup | .NET 8.0           | Swift, warm     |      8.484 ns |   0.0296 ns |   0.0262 ns |  1.00 |    0.00 |      - |      - |         - |          NA |
-| Lookup | .NET 6.0           | Swift, warm     |     17.480 ns |   0.0230 ns |   0.0192 ns |  2.06 |    0.01 |      - |      - |         - |          NA |
-| Lookup | .NET Framework 4.8 | Swift, warm     |     46.586 ns |   0.1078 ns |   0.0842 ns |  5.49 |    0.02 |      - |      - |         - |          NA |
+| Lookup | .NET 8.0           | Swift, warm     |      8.396 ns |   0.0386 ns |   0.0361 ns |  1.00 |    0.01 |      - |      - |         - |          NA |
+| Lookup | .NET 6.0           | Swift, warm     |     17.405 ns |   0.0818 ns |   0.0765 ns |  2.07 |    0.01 |      - |      - |         - |          NA |
+| Lookup | .NET Framework 4.8 | Swift, warm     |     46.590 ns |   0.2670 ns |   0.2084 ns |  5.55 |    0.03 |      - |      - |         - |          NA |
 |        |                    |                 |               |             |             |       |         |        |        |           |             |
-| Lookup | .NET 6.0           | Wikipedia, cold | 14,787.281 ns |  27.0009 ns |  23.9356 ns |  0.72 |    0.01 | 3.5858 | 0.2136 |   22520 B |        0.64 |
-| Lookup | .NET Framework 4.8 | Wikipedia, cold | 17,305.278 ns |  38.4931 ns |  30.0529 ns |  0.85 |    0.02 | 3.5706 | 0.1831 |   22643 B |        0.64 |
-| Lookup | .NET 8.0           | Wikipedia, cold | 20,460.055 ns | 408.9646 ns | 401.6579 ns |  1.00 |    0.03 | 5.5847 | 0.3052 |   35144 B |        1.00 |
+| Lookup | .NET 6.0           | Wikipedia, cold | 14,969.504 ns | 243.0710 ns | 227.3687 ns |  0.73 |    0.01 | 3.5706 | 0.2136 |   22520 B |        0.64 |
+| Lookup | .NET Framework 4.8 | Wikipedia, cold | 18,027.040 ns | 288.7946 ns | 270.1387 ns |  0.88 |    0.01 | 3.5706 | 0.1831 |   22642 B |        0.64 |
+| Lookup | .NET 8.0           | Wikipedia, cold | 20,375.924 ns | 176.6611 ns | 137.9253 ns |  1.00 |    0.01 | 5.5847 | 0.3052 |   35144 B |        1.00 |
 |        |                    |                 |               |             |             |       |         |        |        |           |             |
-| Lookup | .NET 8.0           | Wikipedia, warm |      8.823 ns |   0.0639 ns |   0.0566 ns |  1.00 |    0.01 |      - |      - |         - |          NA |
-| Lookup | .NET 6.0           | Wikipedia, warm |     17.830 ns |   0.1659 ns |   0.1552 ns |  2.02 |    0.02 |      - |      - |         - |          NA |
-| Lookup | .NET Framework 4.8 | Wikipedia, warm |     46.609 ns |   0.7311 ns |   0.6481 ns |  5.28 |    0.08 |      - |      - |         - |          NA |
-
+| Lookup | .NET 8.0           | Wikipedia, warm |      8.401 ns |   0.0482 ns |   0.0451 ns |  1.00 |    0.01 |      - |      - |         - |          NA |
+| Lookup | .NET 6.0           | Wikipedia, warm |     17.483 ns |   0.1148 ns |   0.0959 ns |  2.08 |    0.02 |      - |      - |         - |          NA |
+| Lookup | .NET Framework 4.8 | Wikipedia, warm |     45.350 ns |   0.1471 ns |   0.1304 ns |  5.40 |    0.03 |      - |      - |         - |          NA |
 
 ### CLI
 

--- a/test/IbanNet.Tests/PublicApi/.NET_6.0.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_6.0.verified.txt
@@ -178,9 +178,8 @@ namespace IbanNet
         public IbanNet.Registry.IIbanRegistry Registry { get; set; }
         public System.Collections.Generic.ICollection<IbanNet.Validation.Rules.IIbanValidationRule> Rules { get; }
     }
-    public sealed class ValidationResult
+    public readonly struct ValidationResult : System.IEquatable<IbanNet.ValidationResult>
     {
-        public ValidationResult() { }
         public string? AttemptedValue { get; init; }
         public IbanNet.Registry.IbanCountry? Country { get; init; }
         public IbanNet.Validation.Results.ErrorResult? Error { get; init; }

--- a/test/IbanNet.Tests/PublicApi/.NET_8.0.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_8.0.verified.txt
@@ -181,9 +181,8 @@ namespace IbanNet
         public IbanNet.Registry.IIbanRegistry Registry { get; set; }
         public System.Collections.Generic.ICollection<IbanNet.Validation.Rules.IIbanValidationRule> Rules { get; }
     }
-    public sealed class ValidationResult
+    public readonly struct ValidationResult : System.IEquatable<IbanNet.ValidationResult>
     {
-        public ValidationResult() { }
         public string? AttemptedValue { get; init; }
         public IbanNet.Registry.IbanCountry? Country { get; init; }
         public IbanNet.Validation.Results.ErrorResult? Error { get; init; }

--- a/test/IbanNet.Tests/PublicApi/.NET_Framework_4.6.2.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Framework_4.6.2.verified.txt
@@ -177,9 +177,8 @@ namespace IbanNet
         public IbanNet.Registry.IIbanRegistry Registry { get; set; }
         public System.Collections.Generic.ICollection<IbanNet.Validation.Rules.IIbanValidationRule> Rules { get; }
     }
-    public sealed class ValidationResult
+    public readonly struct ValidationResult : System.IEquatable<IbanNet.ValidationResult>
     {
-        public ValidationResult() { }
         public string? AttemptedValue { get; init; }
         public IbanNet.Registry.IbanCountry? Country { get; init; }
         public IbanNet.Validation.Results.ErrorResult? Error { get; init; }

--- a/test/IbanNet.Tests/PublicApi/.NET_Framework_4.7.2.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Framework_4.7.2.verified.txt
@@ -177,9 +177,8 @@ namespace IbanNet
         public IbanNet.Registry.IIbanRegistry Registry { get; set; }
         public System.Collections.Generic.ICollection<IbanNet.Validation.Rules.IIbanValidationRule> Rules { get; }
     }
-    public sealed class ValidationResult
+    public readonly struct ValidationResult : System.IEquatable<IbanNet.ValidationResult>
     {
-        public ValidationResult() { }
         public string? AttemptedValue { get; init; }
         public IbanNet.Registry.IbanCountry? Country { get; init; }
         public IbanNet.Validation.Results.ErrorResult? Error { get; init; }

--- a/test/IbanNet.Tests/PublicApi/.NET_Standard_2.0_via_.NET_Framework_4.8.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Standard_2.0_via_.NET_Framework_4.8.verified.txt
@@ -177,9 +177,8 @@ namespace IbanNet
         public IbanNet.Registry.IIbanRegistry Registry { get; set; }
         public System.Collections.Generic.ICollection<IbanNet.Validation.Rules.IIbanValidationRule> Rules { get; }
     }
-    public sealed class ValidationResult
+    public readonly struct ValidationResult : System.IEquatable<IbanNet.ValidationResult>
     {
-        public ValidationResult() { }
         public string? AttemptedValue { get; init; }
         public IbanNet.Registry.IbanCountry? Country { get; init; }
         public IbanNet.Validation.Results.ErrorResult? Error { get; init; }

--- a/test/IbanNet.Tests/PublicApi/.NET_Standard_2.1_via_.NET_7.0.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Standard_2.1_via_.NET_7.0.verified.txt
@@ -178,9 +178,8 @@ namespace IbanNet
         public IbanNet.Registry.IIbanRegistry Registry { get; set; }
         public System.Collections.Generic.ICollection<IbanNet.Validation.Rules.IIbanValidationRule> Rules { get; }
     }
-    public sealed class ValidationResult
+    public readonly struct ValidationResult : System.IEquatable<IbanNet.ValidationResult>
     {
-        public ValidationResult() { }
         public string? AttemptedValue { get; init; }
         public IbanNet.Registry.IbanCountry? Country { get; init; }
         public IbanNet.Validation.Results.ErrorResult? Error { get; init; }

--- a/test/IbanNet.Tests/ValidationResultTests.cs
+++ b/test/IbanNet.Tests/ValidationResultTests.cs
@@ -1,23 +1,49 @@
-﻿using IbanNet.Validation.Results;
+﻿using IbanNet.Registry;
+using IbanNet.Validation.Results;
 
 namespace IbanNet;
 
 public class ValidationResultTests
 {
-    [Fact]
-    public void Given_result_is_success_when_getting_isValid_it_should_be_true()
-    {
-        var sut = new ValidationResult();
+    private static readonly ValidationResult SuccessResult = new() { AttemptedValue = "NL91ABNA0417164300", Country = IbanRegistry.Default["NL"] };
 
-        sut.IsValid.Should().BeTrue();
+    [Fact]
+    public void Given_that_result_is_created_with_default_ctor_when_getting_isValid_it_should_return_false()
+    {
+        var result = new ValidationResult();
+        result.IsValid.Should().BeFalse();
     }
 
     [Fact]
-    public void Given_result_is_an_error_when_getting_isValid_it_should_be_false()
+    public void Given_that_result_is_success_when_getting_isValid_it_should_return_true()
     {
-        var sut = new ValidationResult { Error = new ErrorResult("Error") };
+        SuccessResult.IsValid.Should().BeTrue();
+    }
 
-        sut.IsValid.Should().BeFalse();
+    [Fact]
+    public void Given_that_result_has_an_error_when_getting_isValid_it_should_return_false()
+    {
+        ValidationResult sut = SuccessResult with { Error = new ErrorResult("Error") };
+
         sut.Error.Should().NotBeNull();
+        sut.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Given_that_result_is_missing_country_when_getting_isValid_it_should_return_false()
+    {
+        ValidationResult sut = SuccessResult with { Country = null };
+
+        sut.Country.Should().BeNull();
+        sut.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Given_that_result_is_missing_attemptedValue_when_getting_isValid_it_should_return_false()
+    {
+        ValidationResult sut = SuccessResult with { AttemptedValue = null };
+
+        sut.AttemptedValue.Should().BeNull();
+        sut.IsValid.Should().BeFalse();
     }
 }


### PR DESCRIPTION
- no longer need null-reference checks
- adds IEquatable<> which can help to make tests simpler/robust
- reduces heap allocation
- accounts for default ctor not to be valid