### PR TITLE
refactor!: move token match logic to the pattern validator

### DIFF
--- a/src/IbanNet/Registry/Patterns/PatternToken.cs
+++ b/src/IbanNet/Registry/Patterns/PatternToken.cs
@@ -6,7 +6,7 @@ namespace IbanNet.Registry.Patterns;
 /// <summary>
 /// Defines a token that spans one or more characters of the same <see cref="AsciiCategory" />.
 /// </summary>
-public sealed class PatternToken
+public sealed record PatternToken
 {
     /// <summary>
     /// Initializes a new instance of the pattern token that matches a specific string explicitly.

--- a/src/IbanNet/Registry/Patterns/PatternValidator.cs
+++ b/src/IbanNet/Registry/Patterns/PatternValidator.cs
@@ -28,7 +28,7 @@ internal class PatternValidator
         // If no tokens, always fail.
         if (_tokens.Count == 0)
         {
-            errorPos = value.Length;
+            errorPos = 0;
             return false;
         }
 

--- a/test/IbanNet.Tests/PublicApi/.NET_6.0.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_6.0.verified.txt
@@ -300,7 +300,7 @@ namespace IbanNet.Registry.Patterns
     {
         public static string ToRegexPattern(this IbanNet.Registry.Patterns.Pattern pattern) { }
     }
-    public sealed class PatternToken
+    public sealed class PatternToken : System.IEquatable<IbanNet.Registry.Patterns.PatternToken>
     {
         public PatternToken(string value) { }
         public PatternToken(IbanNet.Registry.Patterns.AsciiCategory category, int length) { }

--- a/test/IbanNet.Tests/PublicApi/.NET_8.0.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_8.0.verified.txt
@@ -304,7 +304,7 @@ namespace IbanNet.Registry.Patterns
     {
         public static string ToRegexPattern(this IbanNet.Registry.Patterns.Pattern pattern) { }
     }
-    public sealed class PatternToken
+    public sealed class PatternToken : System.IEquatable<IbanNet.Registry.Patterns.PatternToken>
     {
         public PatternToken(string value) { }
         public PatternToken(IbanNet.Registry.Patterns.AsciiCategory category, int length) { }

--- a/test/IbanNet.Tests/PublicApi/.NET_Framework_4.6.2.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Framework_4.6.2.verified.txt
@@ -289,7 +289,7 @@ namespace IbanNet.Registry.Patterns
     {
         public static string ToRegexPattern(this IbanNet.Registry.Patterns.Pattern pattern) { }
     }
-    public sealed class PatternToken
+    public sealed class PatternToken : System.IEquatable<IbanNet.Registry.Patterns.PatternToken>
     {
         public PatternToken(string value) { }
         public PatternToken(IbanNet.Registry.Patterns.AsciiCategory category, int length) { }

--- a/test/IbanNet.Tests/PublicApi/.NET_Framework_4.7.2.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Framework_4.7.2.verified.txt
@@ -289,7 +289,7 @@ namespace IbanNet.Registry.Patterns
     {
         public static string ToRegexPattern(this IbanNet.Registry.Patterns.Pattern pattern) { }
     }
-    public sealed class PatternToken
+    public sealed class PatternToken : System.IEquatable<IbanNet.Registry.Patterns.PatternToken>
     {
         public PatternToken(string value) { }
         public PatternToken(IbanNet.Registry.Patterns.AsciiCategory category, int length) { }

--- a/test/IbanNet.Tests/PublicApi/.NET_Standard_2.0_via_.NET_Framework_4.8.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Standard_2.0_via_.NET_Framework_4.8.verified.txt
@@ -289,7 +289,7 @@ namespace IbanNet.Registry.Patterns
     {
         public static string ToRegexPattern(this IbanNet.Registry.Patterns.Pattern pattern) { }
     }
-    public sealed class PatternToken
+    public sealed class PatternToken : System.IEquatable<IbanNet.Registry.Patterns.PatternToken>
     {
         public PatternToken(string value) { }
         public PatternToken(IbanNet.Registry.Patterns.AsciiCategory category, int length) { }

--- a/test/IbanNet.Tests/PublicApi/.NET_Standard_2.1_via_.NET_7.0.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Standard_2.1_via_.NET_7.0.verified.txt
@@ -300,7 +300,7 @@ namespace IbanNet.Registry.Patterns
     {
         public static string ToRegexPattern(this IbanNet.Registry.Patterns.Pattern pattern) { }
     }
-    public sealed class PatternToken
+    public sealed class PatternToken : System.IEquatable<IbanNet.Registry.Patterns.PatternToken>
     {
         public PatternToken(string value) { }
         public PatternToken(IbanNet.Registry.Patterns.AsciiCategory category, int length) { }

--- a/test/IbanNet.Tests/Registry/Patterns/PatternTokenTests.cs
+++ b/test/IbanNet.Tests/Registry/Patterns/PatternTokenTests.cs
@@ -100,6 +100,24 @@ public static class PatternTokenTests
             pattern.IsFixedLength.Should().Be(isFixedLength);
         }
 
+        [Theory]
+        [MemberData(nameof(GetCtorAsciiTestCases))]
+        public void When_creating_instance_twice_it_should_equal_each_other
+        (
+            AsciiCategory category,
+            int minLength,
+            int maxLength,
+            bool isFixedLength
+        )
+        {
+            // Act
+            var pattern1 = new PatternToken(category, minLength, maxLength);
+            var pattern2 = new PatternToken(category, minLength, maxLength);
+
+            // Assert
+            pattern1.Equals(pattern2).Should().BeTrue();
+        }
+
         public static IEnumerable<object[]> GetCtorAsciiTestCases()
         {
             yield return [AsciiCategory.Space, 1, 1, true];
@@ -108,6 +126,17 @@ public static class PatternTokenTests
             yield return [AsciiCategory.UppercaseLetter, 3, 4, false];
             yield return [AsciiCategory.Letter, 6, 6, true];
             yield return [AsciiCategory.AlphaNumeric, 3, 3, true];
+        }
+
+        [Fact]
+        public void When_comparing_two_different_instances_for_equality_it_should_not_equal()
+        {
+            // Act
+            var pattern1 = new PatternToken(AsciiCategory.Digit, 1);
+            var pattern2 = new PatternToken(AsciiCategory.Digit, 2);
+
+            // Assert
+            pattern1.Equals(pattern2).Should().BeFalse();
         }
 
         [Theory]
@@ -189,11 +218,39 @@ public static class PatternTokenTests
 #endif
         }
 
+        [Theory]
+        [MemberData(nameof(GetCtorValueTestCases))]
+        public void When_creating_instance_twice_it_should_equal_each_other
+        (
+            string value,
+            int _,
+            int __
+        )
+        {
+            // Act
+            var pattern1 = new PatternToken(value);
+            var pattern2 = new PatternToken(value);
+
+            // Assert
+            pattern1.Equals(pattern2).Should().BeTrue();
+        }
+
         public static IEnumerable<object[]> GetCtorValueTestCases()
         {
             yield return ["A", 1, 1];
             yield return ["AB", 2, 2];
             yield return ["ABCDEF", 6, 6];
+        }
+
+        [Fact]
+        public void When_comparing_two_different_instances_for_equality_it_should_not_equal()
+        {
+            // Act
+            var pattern1 = new PatternToken("AB");
+            var pattern2 = new PatternToken("AC");
+
+            // Assert
+            pattern1.Equals(pattern2).Should().BeFalse();
         }
     }
 }

--- a/test/IbanNet.Tests/Registry/Patterns/PatternValidatorTests.cs
+++ b/test/IbanNet.Tests/Registry/Patterns/PatternValidatorTests.cs
@@ -1,0 +1,109 @@
+﻿namespace IbanNet.Registry.Patterns;
+
+public sealed class PatternValidatorTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Given_that_tokens_are_empty_when_validating_it_should_return_false(bool isFixedLength)
+    {
+        var sut = new PatternValidator([], isFixedLength);
+
+        // Act
+        bool result = sut.TryValidate("ABC", out int? errorPos);
+
+        // Assert
+        result.Should().BeFalse();
+        errorPos.Should().Be(0);
+    }
+
+    public sealed class ValueBasedTests
+    {
+        [Theory]
+        // Single token
+        [InlineData("ABC", null, "ABC")]
+        [InlineData("BCD", 0, "ABC")]
+        [InlineData("AB", 2, "ABC")]
+        [InlineData("ABD", 2, "ABC")]
+        [InlineData("ABCD", 3, "ABC")]
+        // Multiple tokens
+        [InlineData("ABC", null, "AB", "C")]
+        [InlineData("BCD", 0, "A", "BC")]
+        [InlineData("AB", 2, "A", "BC")]
+        [InlineData("ABD", 2, "AB", "C")]
+        [InlineData("ABCD", 3, "AB", "C")]
+        public void Given_that_token_is_value_based_when_validating_it_should_return_expected
+        (
+            string value,
+            int? expectedErrorPos,
+            params string[] tokens)
+        {
+            var tokenList = tokens.Select(t => new PatternToken(t)).ToList();
+            var sut = new PatternValidator(tokenList, true);
+
+            // Act
+            bool result = sut.TryValidate(value, out int? errorPos);
+
+            // Assert
+            result.Should().Be(!expectedErrorPos.HasValue);
+            errorPos.Should().Be(expectedErrorPos);
+        }
+    }
+
+    public sealed class CategoryBasedTests
+    {
+        [Theory]
+        [InlineData("   ", null, AsciiCategory.Space, 1, 3)] // Input contains spaces only, valid length range is 1-3, no error expected.
+        [InlineData("A  ", 0, AsciiCategory.Space, 1, 3)] // Input contains a letter followed by spaces, error at position 0.
+        [InlineData("    ", 3, AsciiCategory.Space, 1, 3)] // Input exceeds the maximum length of 3, error at position 3.
+        [InlineData("", 0, AsciiCategory.Space, 1, 3)] // Input is empty, error at position 0 due to minimum length requirement.
+        [InlineData("12345", null, AsciiCategory.Digit, 5, 5)] // Input contains digits only, valid fixed length of 5, no error expected.
+        [InlineData("12A45", 2, AsciiCategory.Digit, 5, 5)] // Input contains a non-digit at position 2, error at position 2.
+        [InlineData("123456", 5, AsciiCategory.Digit, 5, 5)] // Input exceeds the fixed length of 5, error at position 5.
+        [InlineData("123", 3, AsciiCategory.Digit, 5, 5)] // Input is shorter than the fixed length of 5, error at position 3.
+        [InlineData("ABC", null, AsciiCategory.UppercaseLetter, 3, 3)] // Input contains uppercase letters only, valid fixed length of 3, no error expected.
+        [InlineData("AbC", 1, AsciiCategory.UppercaseLetter, 3, 3)] // Input contains a lowercase letter at position 1, error at position 1.
+        [InlineData("ABCD", 3, AsciiCategory.UppercaseLetter, 3, 3)] // Input exceeds the fixed length of 3, error at position 3.
+        [InlineData("AB", 2, AsciiCategory.UppercaseLetter, 3, 3)] // Input is shorter than the fixed length of 3, error at position 2.
+        [InlineData("abc", null, AsciiCategory.LowercaseLetter, 3, 3)] // Input contains lowercase letters only, valid fixed length of 3, no error expected.
+        [InlineData("aBc", 1, AsciiCategory.LowercaseLetter, 3, 3)] // Input contains an uppercase letter at position 1, error at position 1.
+        [InlineData("abcd", 3, AsciiCategory.LowercaseLetter, 3, 3)] // Input exceeds the fixed length of 3, error at position 3.
+        [InlineData("ab", 2, AsciiCategory.LowercaseLetter, 3, 3)] // Input is shorter than the fixed length of 3, error at position 2.
+        [InlineData("abcABC", null, AsciiCategory.Letter, 3, 6)] // Input contains mixed case letters, valid length range is 3-6, no error expected.
+        [InlineData("abc123", 3, AsciiCategory.Letter, 3, 6)] // Input contains digits starting at position 3, error at position 3.
+        [InlineData("abcABCD", 6, AsciiCategory.Letter, 3, 6)] // Input exceeds the maximum length of 6, error at position 6.
+        [InlineData("ab", 2, AsciiCategory.Letter, 3, 6)] // Input is shorter than the minimum length of 3, error at position 2.
+        [InlineData("12", null, AsciiCategory.Digit, 2, 5)] // Input contains digits only, valid length range is 2-5, no error expected.
+        [InlineData("123", null, AsciiCategory.Digit, 2, 5)] // Input contains digits only, valid length range is 2-5, no error expected.
+        [InlineData("12345", null, AsciiCategory.Digit, 2, 5)] // Input contains digits only, valid length range is 2-5, no error expected.
+        [InlineData("123456", 5, AsciiCategory.Digit, 2, 5)] // Input exceeds the maximum length of 5, error at position 5.
+        [InlineData("1", 1, AsciiCategory.Digit, 2, 5)] // Input is shorter than the minimum length of 2, error at position 1.
+        [InlineData("aBc123", null, AsciiCategory.AlphaNumeric, 6, 6)] // Input contains alphanumeric characters, valid fixed length of 6, no error expected.
+        [InlineData("aBc123!", 6, AsciiCategory.AlphaNumeric, 6, 6)] // Input contains a non-alphanumeric character at position 6, error at position 6.
+        [InlineData("123", null, AsciiCategory.AlphaNumeric, 3, 6)] // Input contains digits only, valid length range is 3-6, no error expected.
+        [InlineData("aBc", null, AsciiCategory.AlphaNumeric, 3, 6)] // Input contains letters only, valid length range is 3-6, no error expected.
+        [InlineData("aBc123", null, AsciiCategory.AlphaNumeric, 3, 6)] // Input contains alphanumeric characters, valid length range is 3-6, no error expected.
+        [InlineData("aBc1234", 6, AsciiCategory.AlphaNumeric, 3, 6)] // Input exceeds the maximum length of 6, error at position 6.
+        [InlineData("1", 1, AsciiCategory.AlphaNumeric, 2, 5)] // Input is shorter than the minimum length of 2, error at position 1.
+        [InlineData("1B", null, AsciiCategory.AlphaNumeric, 2, 5)] // Input contains digits only, valid length range is 2-5, no error expected.
+        [InlineData("aBc45", null, AsciiCategory.AlphaNumeric, 2, 5)] // Input contains digits only, valid length range is 2-5, no error expected.
+        [InlineData("aBc456", 5, AsciiCategory.AlphaNumeric, 2, 5)] // Input exceeds the maximum length of 5, error at position 5.
+        public void Given_that_single_token_is_category_based_when_validating_it_should_return_expected
+        (
+            string value,
+            int? expectedErrorPos,
+            AsciiCategory category,
+            int minLength,
+            int maxLength)
+        {
+            var sut = new PatternValidator([new PatternToken(category, minLength, maxLength)], minLength == maxLength);
+
+            // Act
+            bool result = sut.TryValidate(value, out int? errorPos);
+
+            // Assert
+            result.Should().Be(!expectedErrorPos.HasValue);
+            errorPos.Should().Be(expectedErrorPos);
+        }
+    }
+}


### PR DESCRIPTION
The match logic belongs in the validator in the first place.

Also added `IEquatable<>` which can help to make test assertions simpler/robust, and added some more guards/coverage.