### PR TITLE
perf: defer initializing pattern properties

### DIFF
--- a/src/IbanNet/Internal/ListsMarshal.cs
+++ b/src/IbanNet/Internal/ListsMarshal.cs
@@ -1,0 +1,23 @@
+﻿#if NET6_0_OR_GREATER
+using System.Runtime.InteropServices;
+
+namespace IbanNet.Internal;
+
+internal static class ListsMarshal
+{
+    internal static Span<T> AsSpan<T>(IEnumerable<T>? list)
+    {
+        return list switch
+        {
+            null => default,
+            ICollection<T> { Count: 0 } => default,
+            T[] arr => arr.AsSpan(),
+            List<T> lst => CollectionsMarshal.AsSpan(lst),
+            // Special case, JIT can optimize to a special 'single item list', in which case instead of iterating/copying we create a span over a single item array.
+            IList<T> { Count: 1 } ilst => new Span<T>([ilst[0]]),
+            // Unoptimized, we have to copy.
+            _ => list.ToArray().AsSpan()
+        };
+    }
+}
+#endif

--- a/src/IbanNet/Registry/Patterns/PatternExtensions.cs
+++ b/src/IbanNet/Registry/Patterns/PatternExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using IbanNet.Internal;
 
 namespace IbanNet.Registry.Patterns;
 
@@ -73,7 +74,7 @@ public static class PatternExtensions
         var compressedTokens = new List<PatternToken>(tokens.Count);
 
 #if NET6_0_OR_GREATER
-        Span<PatternToken> tokenSpan = CollectionsMarshal.AsSpan(tokens as List<PatternToken> ?? tokens.ToList());
+        Span<PatternToken> tokenSpan = ListsMarshal.AsSpan(tokens);
         PatternToken current = tokenSpan[0];
         Span<PatternToken> tokensExceptFirst = tokenSpan[1..];
         foreach (ref readonly PatternToken token in tokensExceptFirst)

--- a/test/IbanNet.Tests/Internal/ListsMarshalTests.cs
+++ b/test/IbanNet.Tests/Internal/ListsMarshalTests.cs
@@ -1,0 +1,94 @@
+﻿#if NET6_0 || NET8_0_OR_GREATER
+using System.Collections.ObjectModel;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace IbanNet.Internal;
+
+public sealed class ListsMarshalTests
+{
+    [Fact]
+    public void Given_that_input_is_null_when_getting_span_it_should_return_default()
+    {
+        Span<int> actual = ListsMarshal.AsSpan((List<int>)null!);
+
+        // Assert
+        actual.Length.Should().Be(0);
+    }
+
+    [Fact]
+    public void Given_that_input_is_empty_when_getting_span_it_should_return_default()
+    {
+        Span<int> actual = ListsMarshal.AsSpan(new List<int>());
+
+        // Assert
+        actual.Length.Should().Be(0);
+    }
+
+    [Fact]
+    public void Given_that_input_is_array_when_getting_span_it_should_return_span_wrapping_the_array()
+    {
+        int[] arr = [1, 2, 3];
+
+        // Act
+        Span<int> actual = ListsMarshal.AsSpan(arr);
+
+        // Assert
+        actual.Length.Should().Be(3);
+        actual[0].Should().Be(1);
+        actual[1].Should().Be(2);
+        actual[2].Should().Be(3);
+
+        ref int src = ref MemoryMarshal.GetArrayDataReference(arr);
+        ref int dest = ref actual.GetPinnableReference();
+        Unsafe.AreSame(ref src, ref dest).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Given_that_input_is_list_when_getting_span_it_should_return_span_wrapping_the_list()
+    {
+        List<int> list = [4, 5, 6];
+
+        // Act
+        Span<int> actual = ListsMarshal.AsSpan(list);
+
+        // Assert
+        actual.Length.Should().Be(3);
+        actual[0].Should().Be(4);
+        actual[1].Should().Be(5);
+        actual[2].Should().Be(6);
+
+        ref int src = ref CollectionsMarshal.AsSpan(list).GetPinnableReference();
+        ref int dest = ref actual.GetPinnableReference();
+        Unsafe.AreSame(ref src, ref dest).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Given_that_input_is_single_element_not_in_a_list_or_array_when_getting_span_it_should_return_single_element_span()
+    {
+        var readOnlyList = new ReadOnlyCollection<int>((int[])[1]);
+
+        // Act
+        Span<int> actual = ListsMarshal.AsSpan(readOnlyList);
+
+        // Assert
+        actual.Length.Should().Be(1);
+        actual[0].Should().Be(1);
+    }
+
+    [Fact]
+    public void Given_that_input_is_not_a_list_or_array_when_getting_span_it_should_return_span_as_copy()
+    {
+        var list = new ReadOnlyCollection<int>((int[])[7, 8, 9]);
+
+        // Act
+        Span<int> actual = ListsMarshal.AsSpan(list);
+
+        // Assert
+        actual.Length.Should().Be(3);
+        actual[0].Should().Be(7);
+        actual[1].Should().Be(8);
+        actual[2].Should().Be(9);
+    }
+}
+#endif


### PR DESCRIPTION
Via the ctor accepting enumerable, for each pattern we currently iterate all tokens to determine if the pattern is fixed length and what the max length is. Even though this currently is not an issue as we use the other ctor and not use the tokens directly during validation, future refactors will benefit from this as we migrate (internal) functionality to utilize this ctor.
