### PR TITLE
chore!: remove obsolete enum member AsciiCategory.Other

### DIFF
--- a/src/IbanNet/Registry/Patterns/AsciiCategory.cs
+++ b/src/IbanNet/Registry/Patterns/AsciiCategory.cs
@@ -4,25 +4,12 @@
 /// Defines the ASCII category of a character.
 /// </summary>
 [Flags]
-#pragma warning disable S2342 // Enumeration types should comply with a naming convention - justification: breaking change
-#pragma warning disable CA1008
 public enum AsciiCategory
-#pragma warning restore CA1008
-#pragma warning restore S2342
 {
     /// <summary>
     /// No ASCII category.
     /// </summary>
     None = 0,
-
-    /// <summary>
-    /// No ASCII category.
-    /// </summary>
-    [Obsolete("Use None instead.", true)]
-#pragma warning disable CA1069
-    // ReSharper disable once UnusedMember.Global
-    Other = 0,
-#pragma warning restore CA1069
 
     /// <summary>
     /// The space character.

--- a/test/IbanNet.Tests/PublicApi/.NET_8.0.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_8.0.verified.txt
@@ -274,8 +274,6 @@ namespace IbanNet.Registry.Patterns
     public enum AsciiCategory
     {
         None = 0,
-        [System.Obsolete("Use None instead.", true)]
-        Other = 0,
         Space = 1,
         Digit = 2,
         UppercaseLetter = 4,

--- a/test/IbanNet.Tests/PublicApi/.NET_Framework_4.6.2.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Framework_4.6.2.verified.txt
@@ -260,8 +260,6 @@ namespace IbanNet.Registry.Patterns
     public enum AsciiCategory
     {
         None = 0,
-        [System.Obsolete("Use None instead.", true)]
-        Other = 0,
         Space = 1,
         Digit = 2,
         UppercaseLetter = 4,

--- a/test/IbanNet.Tests/PublicApi/.NET_Framework_4.7.2.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Framework_4.7.2.verified.txt
@@ -260,8 +260,6 @@ namespace IbanNet.Registry.Patterns
     public enum AsciiCategory
     {
         None = 0,
-        [System.Obsolete("Use None instead.", true)]
-        Other = 0,
         Space = 1,
         Digit = 2,
         UppercaseLetter = 4,

--- a/test/IbanNet.Tests/PublicApi/.NET_Standard_2.0_via_.NET_Framework_4.8.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Standard_2.0_via_.NET_Framework_4.8.verified.txt
@@ -260,8 +260,6 @@ namespace IbanNet.Registry.Patterns
     public enum AsciiCategory
     {
         None = 0,
-        [System.Obsolete("Use None instead.", true)]
-        Other = 0,
         Space = 1,
         Digit = 2,
         UppercaseLetter = 4,

--- a/test/IbanNet.Tests/PublicApi/.NET_Standard_2.1_via_.NET_6.0.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Standard_2.1_via_.NET_6.0.verified.txt
@@ -271,8 +271,6 @@ namespace IbanNet.Registry.Patterns
     public enum AsciiCategory
     {
         None = 0,
-        [System.Obsolete("Use None instead.", true)]
-        Other = 0,
         Space = 1,
         Digit = 2,
         UppercaseLetter = 4,

--- a/test/IbanNet.Tests/Registry/Patterns/PatternTokenTests.cs
+++ b/test/IbanNet.Tests/Registry/Patterns/PatternTokenTests.cs
@@ -211,11 +211,7 @@ public static class PatternTokenTests
             pattern.MinLength.Should().Be(minLength);
             pattern.MaxLength.Should().Be(maxLength);
             pattern.IsFixedLength.Should().BeTrue();
-#if NET8_0_OR_GREATER
             pattern.ToString().Should().Be($"None[{maxLength}]");
-#else
-            pattern.ToString().Should().Be($"Other[{maxLength}]");
-#endif
         }
 
         [Theory]

--- a/test/IbanNet.Tests/Registry/Swift/Snapshots/SwiftRegistryProvider.verified.txt
+++ b/test/IbanNet.Tests/Registry/Swift/Snapshots/SwiftRegistryProvider.verified.txt
@@ -18,17 +18,17 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -50,22 +50,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -82,7 +82,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -99,7 +99,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -128,12 +128,12 @@
         MaxLength: 19,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -155,17 +155,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -182,7 +182,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -215,12 +215,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -242,17 +242,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -269,7 +269,7 @@
         MaxLength: 8,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           }
@@ -286,7 +286,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -315,12 +315,12 @@
         MaxLength: 16,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           }
@@ -342,17 +342,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           }
@@ -369,7 +369,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -402,12 +402,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 20
           }
@@ -429,17 +429,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 20
           }
@@ -456,7 +456,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -489,22 +489,22 @@
         MaxLength: 16,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -526,27 +526,27 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -563,7 +563,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -580,7 +580,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -609,17 +609,17 @@
         MaxLength: 12,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 7
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -641,22 +641,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 7
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -673,7 +673,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -706,22 +706,22 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 8
           }
@@ -743,27 +743,27 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 8
           }
@@ -780,7 +780,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -797,7 +797,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -826,12 +826,12 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 14
           }
@@ -853,17 +853,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 14
           }
@@ -880,7 +880,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -913,22 +913,22 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -950,27 +950,27 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -987,7 +987,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -1004,7 +1004,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -1033,27 +1033,27 @@
         MaxLength: 25,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 1
           }
@@ -1075,32 +1075,32 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 1
           }
@@ -1117,7 +1117,7 @@
         MaxLength: 8,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           }
@@ -1134,7 +1134,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -1163,17 +1163,17 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -1195,22 +1195,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -1227,7 +1227,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 4
           }
@@ -1260,12 +1260,12 @@
         MaxLength: 17,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -1287,17 +1287,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -1314,7 +1314,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -1347,12 +1347,12 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 14
           }
@@ -1374,17 +1374,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 14
           }
@@ -1401,7 +1401,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -1434,17 +1434,17 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -1466,22 +1466,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -1498,7 +1498,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -1515,7 +1515,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -1544,17 +1544,17 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           }
@@ -1576,22 +1576,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           }
@@ -1608,7 +1608,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -1641,12 +1641,12 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           }
@@ -1668,17 +1668,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           }
@@ -1695,7 +1695,7 @@
         MaxLength: 8,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           }
@@ -1728,22 +1728,22 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -1765,27 +1765,27 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -1802,7 +1802,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -1819,7 +1819,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -1848,17 +1848,17 @@
         MaxLength: 14,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 9
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           }
@@ -1880,22 +1880,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 9
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           }
@@ -1912,7 +1912,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -1945,12 +1945,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -1972,17 +1972,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -1999,7 +1999,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 4
           }
@@ -2032,12 +2032,12 @@
         MaxLength: 16,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 14
           }
@@ -2059,17 +2059,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 14
           }
@@ -2086,7 +2086,7 @@
         MaxLength: 2,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -2119,17 +2119,17 @@
         MaxLength: 25,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 17
           }
@@ -2151,22 +2151,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 17
           }
@@ -2183,7 +2183,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -2200,7 +2200,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -2229,27 +2229,27 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           }
@@ -2271,32 +2271,32 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           }
@@ -2313,7 +2313,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -2330,7 +2330,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -2365,12 +2365,12 @@
         MaxLength: 14,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           }
@@ -2392,17 +2392,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           }
@@ -2419,7 +2419,7 @@
         MaxLength: 6,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           }
@@ -2452,12 +2452,12 @@
         MaxLength: 14,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           }
@@ -2479,17 +2479,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           }
@@ -2506,7 +2506,7 @@
         MaxLength: 2,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 2
           }
@@ -2539,17 +2539,17 @@
         MaxLength: 14,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 9
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           }
@@ -2571,22 +2571,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 9
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           }
@@ -2603,7 +2603,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -2660,22 +2660,22 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -2697,27 +2697,27 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -2734,7 +2734,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -2751,7 +2751,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -2785,17 +2785,17 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           }
@@ -2817,22 +2817,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           }
@@ -2849,7 +2849,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -2866,7 +2866,7 @@
         MaxLength: 6,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           }
@@ -2895,12 +2895,12 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -2922,17 +2922,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -2949,7 +2949,7 @@
         MaxLength: 2,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 2
           }
@@ -2982,12 +2982,12 @@
         MaxLength: 19,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 15
           }
@@ -3009,17 +3009,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 15
           }
@@ -3036,7 +3036,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -3069,17 +3069,17 @@
         MaxLength: 14,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 9
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           }
@@ -3101,22 +3101,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 9
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           }
@@ -3133,7 +3133,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -3166,17 +3166,17 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -3198,22 +3198,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -3230,7 +3230,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -3247,7 +3247,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -3276,12 +3276,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 20
           }
@@ -3303,17 +3303,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 20
           }
@@ -3330,7 +3330,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 4
           }
@@ -3363,12 +3363,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -3390,17 +3390,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -3417,7 +3417,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -3450,12 +3450,12 @@
         MaxLength: 17,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 7
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           }
@@ -3477,17 +3477,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 7
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           }
@@ -3504,7 +3504,7 @@
         MaxLength: 7,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 7
           }
@@ -3537,27 +3537,27 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 15
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           }
@@ -3579,32 +3579,32 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 15
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           }
@@ -3621,7 +3621,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -3638,7 +3638,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -3667,17 +3667,17 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           }
@@ -3699,22 +3699,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           }
@@ -3731,7 +3731,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -3748,7 +3748,7 @@
         MaxLength: 6,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           }
@@ -3777,17 +3777,17 @@
         MaxLength: 19,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 13
           }
@@ -3809,22 +3809,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 13
           }
@@ -3841,7 +3841,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -3858,7 +3858,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -3887,17 +3887,17 @@
         MaxLength: 19,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           }
@@ -3919,22 +3919,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           }
@@ -3951,7 +3951,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -3968,7 +3968,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -3997,22 +3997,22 @@
         MaxLength: 22,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           }
@@ -4034,27 +4034,27 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           }
@@ -4071,7 +4071,7 @@
         MaxLength: 2,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -4088,7 +4088,7 @@
         MaxLength: 2,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -4117,22 +4117,22 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -4154,27 +4154,27 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -4191,7 +4191,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -4208,7 +4208,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -4237,17 +4237,17 @@
         MaxLength: 26,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -4269,22 +4269,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -4301,7 +4301,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -4318,7 +4318,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -4347,12 +4347,12 @@
         MaxLength: 26,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 22
           }
@@ -4374,17 +4374,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 22
           }
@@ -4401,7 +4401,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -4434,12 +4434,12 @@
         MaxLength: 16,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 13
           }
@@ -4461,17 +4461,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 13
           }
@@ -4488,7 +4488,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -4521,12 +4521,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 20
           }
@@ -4548,17 +4548,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 20
           }
@@ -4575,7 +4575,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -4608,12 +4608,12 @@
         MaxLength: 28,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 24
           }
@@ -4635,17 +4635,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 24
           }
@@ -4662,7 +4662,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -4695,12 +4695,12 @@
         MaxLength: 17,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -4722,17 +4722,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -4749,7 +4749,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -4782,12 +4782,12 @@
         MaxLength: 16,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           }
@@ -4809,17 +4809,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           }
@@ -4836,7 +4836,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -4869,12 +4869,12 @@
         MaxLength: 16,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 13
           }
@@ -4896,17 +4896,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 13
           }
@@ -4923,7 +4923,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -4956,12 +4956,12 @@
         MaxLength: 17,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 13
           }
@@ -4983,17 +4983,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 13
           }
@@ -5010,7 +5010,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -5043,17 +5043,17 @@
         MaxLength: 21,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 15
           }
@@ -5075,22 +5075,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 15
           }
@@ -5107,7 +5107,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -5124,7 +5124,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -5153,22 +5153,22 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -5190,27 +5190,27 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -5227,7 +5227,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -5244,7 +5244,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -5273,12 +5273,12 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -5300,17 +5300,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -5327,7 +5327,7 @@
         MaxLength: 2,
         Tokens: [
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 2
           }
@@ -5360,17 +5360,17 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 13
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -5392,22 +5392,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 13
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -5424,7 +5424,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -5457,17 +5457,17 @@
         MaxLength: 15,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 10
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -5489,22 +5489,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 10
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -5521,7 +5521,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -5554,12 +5554,12 @@
         MaxLength: 16,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           }
@@ -5581,17 +5581,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           }
@@ -5608,7 +5608,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -5641,22 +5641,22 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -5678,27 +5678,27 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -5715,7 +5715,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -5732,7 +5732,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -5761,17 +5761,17 @@
         MaxLength: 27,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -5793,22 +5793,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -5825,7 +5825,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -5842,7 +5842,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -5871,32 +5871,32 @@
         MaxLength: 26,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 3
           }
@@ -5918,37 +5918,37 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 3
           }
@@ -5965,7 +5965,7 @@
         MaxLength: 6,
         Tokens: [
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 6
           }
@@ -5982,7 +5982,7 @@
         MaxLength: 2,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -6011,12 +6011,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -6038,17 +6038,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -6065,7 +6065,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -6098,12 +6098,12 @@
         MaxLength: 14,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           }
@@ -6125,17 +6125,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           }
@@ -6152,7 +6152,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -6185,17 +6185,17 @@
         MaxLength: 11,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           }
@@ -6217,22 +6217,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           }
@@ -6249,7 +6249,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -6282,12 +6282,12 @@
         MaxLength: 19,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -6309,17 +6309,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -6336,7 +6336,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -6369,12 +6369,12 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -6396,17 +6396,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -6423,7 +6423,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -6456,12 +6456,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -6483,17 +6483,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -6514,7 +6514,7 @@
         MaxLength: 8,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           }
@@ -6543,12 +6543,12 @@
         MaxLength: 25,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 21
           }
@@ -6570,17 +6570,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 21
           }
@@ -6597,7 +6597,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -6634,22 +6634,22 @@
         MaxLength: 21,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -6671,27 +6671,27 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -6708,7 +6708,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -6725,7 +6725,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -6754,12 +6754,12 @@
         MaxLength: 25,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 21
           }
@@ -6781,17 +6781,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 21
           }
@@ -6808,7 +6808,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -6841,12 +6841,12 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -6868,17 +6868,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -6895,7 +6895,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -6928,17 +6928,17 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 13
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -6960,22 +6960,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 13
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -6992,7 +6992,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -7025,12 +7025,12 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -7052,17 +7052,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -7079,7 +7079,7 @@
         MaxLength: 2,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -7112,27 +7112,27 @@
         MaxLength: 27,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 3
           }
@@ -7154,32 +7154,32 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 3
           }
@@ -7196,12 +7196,12 @@
         MaxLength: 6,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -7218,7 +7218,7 @@
         MaxLength: 2,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -7247,12 +7247,12 @@
         MaxLength: 14,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           }
@@ -7274,17 +7274,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           }
@@ -7301,7 +7301,7 @@
         MaxLength: 2,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -7334,17 +7334,17 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           }
@@ -7366,22 +7366,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           }
@@ -7398,7 +7398,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -7431,17 +7431,17 @@
         MaxLength: 15,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -7463,22 +7463,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -7495,7 +7495,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -7528,17 +7528,17 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           }
@@ -7560,22 +7560,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           }
@@ -7592,7 +7592,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -7625,22 +7625,22 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -7662,27 +7662,27 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -7699,7 +7699,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -7716,7 +7716,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -7745,17 +7745,17 @@
         MaxLength: 19,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           }
@@ -7777,22 +7777,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           }
@@ -7809,7 +7809,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -7826,7 +7826,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -7855,17 +7855,17 @@
         MaxLength: 21,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -7887,22 +7887,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -7919,7 +7919,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -7936,7 +7936,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }
@@ -7965,12 +7965,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -7992,17 +7992,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -8019,7 +8019,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -8052,17 +8052,17 @@
         MaxLength: 19,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 14
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -8084,22 +8084,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 14
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -8116,7 +8116,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -8149,22 +8149,22 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 13
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -8186,27 +8186,27 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 13
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -8223,7 +8223,7 @@
         MaxLength: 2,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -8240,7 +8240,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -8269,17 +8269,17 @@
         MaxLength: 22,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -8301,22 +8301,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -8333,7 +8333,7 @@
         MaxLength: 5,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           }
@@ -8366,12 +8366,12 @@
         MaxLength: 25,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 19
           }
@@ -8393,17 +8393,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 19
           }
@@ -8420,7 +8420,7 @@
         MaxLength: 6,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           }
@@ -8453,12 +8453,12 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 15
           }
@@ -8480,17 +8480,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 15
           }
@@ -8507,7 +8507,7 @@
         MaxLength: 3,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           }
@@ -8540,12 +8540,12 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -8567,17 +8567,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -8594,7 +8594,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -8627,17 +8627,17 @@
         MaxLength: 16,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -8659,22 +8659,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -8691,7 +8691,7 @@
         MaxLength: 2,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -8708,7 +8708,7 @@
         MaxLength: 2,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -8737,17 +8737,17 @@
         MaxLength: 26,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -8769,22 +8769,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -8801,7 +8801,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           }
@@ -8818,7 +8818,7 @@
         MaxLength: 4,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           }

--- a/test/IbanNet.Tests/Registry/Wikipedia/Snapshots/WikipediaRegistryProvider.verified.txt
+++ b/test/IbanNet.Tests/Registry/Wikipedia/Snapshots/WikipediaRegistryProvider.verified.txt
@@ -14,12 +14,12 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -41,17 +41,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -82,12 +82,12 @@
         MaxLength: 19,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -109,17 +109,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -150,12 +150,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -177,17 +177,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -218,7 +218,7 @@
         MaxLength: 21,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 21
           }
@@ -240,12 +240,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 21
           }
@@ -276,7 +276,7 @@
         MaxLength: 16,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -298,12 +298,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -334,12 +334,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 20
           }
@@ -361,17 +361,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 20
           }
@@ -402,7 +402,7 @@
         MaxLength: 16,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -424,12 +424,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -460,7 +460,7 @@
         MaxLength: 12,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           }
@@ -482,12 +482,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           }
@@ -518,12 +518,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -545,17 +545,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -586,17 +586,17 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 8
           }
@@ -618,22 +618,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 8
           }
@@ -664,12 +664,12 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 14
           }
@@ -691,17 +691,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 14
           }
@@ -732,22 +732,22 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -769,27 +769,27 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -820,12 +820,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -847,17 +847,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -888,17 +888,17 @@
         MaxLength: 25,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 1
           }
@@ -920,22 +920,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 1
           }
@@ -966,17 +966,17 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -998,22 +998,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -1044,7 +1044,7 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           }
@@ -1066,12 +1066,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           }
@@ -1102,7 +1102,7 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           }
@@ -1124,12 +1124,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           }
@@ -1160,12 +1160,12 @@
         MaxLength: 17,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -1187,17 +1187,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -1228,12 +1228,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -1255,17 +1255,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -1296,7 +1296,7 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           }
@@ -1318,12 +1318,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           }
@@ -1354,7 +1354,7 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 18
           }
@@ -1376,12 +1376,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 18
           }
@@ -1412,7 +1412,7 @@
         MaxLength: 21,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 21
           }
@@ -1434,12 +1434,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 21
           }
@@ -1470,12 +1470,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -1497,17 +1497,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -1538,7 +1538,7 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -1560,12 +1560,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -1596,7 +1596,7 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 18
           }
@@ -1618,12 +1618,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 18
           }
@@ -1654,22 +1654,22 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -1691,27 +1691,27 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -1742,7 +1742,7 @@
         MaxLength: 14,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 14
           }
@@ -1764,12 +1764,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 14
           }
@@ -1800,12 +1800,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -1827,17 +1827,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -1868,7 +1868,7 @@
         MaxLength: 22,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -1890,12 +1890,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -1926,7 +1926,7 @@
         MaxLength: 16,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -1948,12 +1948,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -1984,7 +1984,7 @@
         MaxLength: 25,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 25
           }
@@ -2006,12 +2006,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 25
           }
@@ -2042,7 +2042,7 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -2064,12 +2064,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -2100,7 +2100,7 @@
         MaxLength: 14,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 14
           }
@@ -2122,12 +2122,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 14
           }
@@ -2158,12 +2158,12 @@
         MaxLength: 14,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           }
@@ -2185,17 +2185,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           }
@@ -2226,7 +2226,7 @@
         MaxLength: 14,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 14
           }
@@ -2248,12 +2248,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 14
           }
@@ -2284,17 +2284,17 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -2316,22 +2316,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -2362,7 +2362,7 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           }
@@ -2384,12 +2384,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           }
@@ -2420,12 +2420,12 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 14
           }
@@ -2447,17 +2447,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 14
           }
@@ -2488,12 +2488,12 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -2515,17 +2515,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -2556,12 +2556,12 @@
         MaxLength: 19,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 15
           }
@@ -2583,17 +2583,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 15
           }
@@ -2624,7 +2624,7 @@
         MaxLength: 14,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 14
           }
@@ -2646,12 +2646,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 14
           }
@@ -2682,7 +2682,7 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           }
@@ -2704,12 +2704,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           }
@@ -2740,12 +2740,12 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 7
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -2767,17 +2767,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 7
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -2808,12 +2808,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 20
           }
@@ -2835,17 +2835,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 20
           }
@@ -2876,12 +2876,12 @@
         MaxLength: 21,
         Tokens: [
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 19
           }
@@ -2903,17 +2903,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 19
           }
@@ -2944,12 +2944,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -2971,17 +2971,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -3012,7 +3012,7 @@
         MaxLength: 17,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 17
           }
@@ -3034,12 +3034,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 17
           }
@@ -3070,7 +3070,7 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 24
           }
@@ -3092,12 +3092,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 24
           }
@@ -3128,17 +3128,17 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           }
@@ -3160,22 +3160,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 8
           }
@@ -3206,7 +3206,7 @@
         MaxLength: 19,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 19
           }
@@ -3228,12 +3228,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 19
           }
@@ -3264,12 +3264,12 @@
         MaxLength: 19,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 15
           }
@@ -3291,17 +3291,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 15
           }
@@ -3332,7 +3332,7 @@
         MaxLength: 22,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -3354,12 +3354,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -3390,7 +3390,7 @@
         MaxLength: 22,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -3412,12 +3412,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -3448,17 +3448,17 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -3480,22 +3480,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -3526,17 +3526,17 @@
         MaxLength: 26,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -3558,22 +3558,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -3604,7 +3604,7 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           }
@@ -3626,12 +3626,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           }
@@ -3662,12 +3662,12 @@
         MaxLength: 26,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 22
           }
@@ -3689,17 +3689,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 22
           }
@@ -3730,12 +3730,12 @@
         MaxLength: 16,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 13
           }
@@ -3757,17 +3757,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 13
           }
@@ -3798,12 +3798,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 20
           }
@@ -3825,17 +3825,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 20
           }
@@ -3866,12 +3866,12 @@
         MaxLength: 28,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 24
           }
@@ -3893,17 +3893,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 24
           }
@@ -3934,12 +3934,12 @@
         MaxLength: 17,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -3961,17 +3961,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -4002,7 +4002,7 @@
         MaxLength: 16,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -4024,12 +4024,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -4060,12 +4060,12 @@
         MaxLength: 16,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 13
           }
@@ -4087,17 +4087,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 13
           }
@@ -4128,12 +4128,12 @@
         MaxLength: 17,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 13
           }
@@ -4155,17 +4155,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 13
           }
@@ -4196,7 +4196,7 @@
         MaxLength: 21,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 21
           }
@@ -4218,12 +4218,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 21
           }
@@ -4254,7 +4254,7 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 24
           }
@@ -4276,12 +4276,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 24
           }
@@ -4312,17 +4312,17 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -4344,22 +4344,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 11
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -4390,12 +4390,12 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -4417,17 +4417,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -4458,7 +4458,7 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 18
           }
@@ -4480,12 +4480,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 18
           }
@@ -4516,7 +4516,7 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           }
@@ -4538,12 +4538,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           }
@@ -4574,17 +4574,17 @@
         MaxLength: 15,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 10
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -4606,22 +4606,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 10
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -4652,12 +4652,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -4679,17 +4679,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -4720,12 +4720,12 @@
         MaxLength: 16,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           }
@@ -4747,17 +4747,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           }
@@ -4788,7 +4788,7 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           }
@@ -4810,12 +4810,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           }
@@ -4846,17 +4846,17 @@
         MaxLength: 27,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -4878,22 +4878,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -4924,17 +4924,17 @@
         MaxLength: 26,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 19
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 3
           }
@@ -4956,22 +4956,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 19
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 3
           }
@@ -5002,7 +5002,7 @@
         MaxLength: 21,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 21
           }
@@ -5024,12 +5024,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 21
           }
@@ -5060,12 +5060,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -5087,17 +5087,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -5128,12 +5128,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -5155,17 +5155,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -5196,12 +5196,12 @@
         MaxLength: 14,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           }
@@ -5223,17 +5223,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           }
@@ -5264,7 +5264,7 @@
         MaxLength: 11,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           }
@@ -5286,12 +5286,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 11
           }
@@ -5322,12 +5322,12 @@
         MaxLength: 19,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -5349,17 +5349,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -5390,12 +5390,12 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -5417,17 +5417,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -5458,7 +5458,7 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 24
           }
@@ -5480,12 +5480,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 24
           }
@@ -5516,12 +5516,12 @@
         MaxLength: 25,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 21
           }
@@ -5543,17 +5543,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 21
           }
@@ -5584,7 +5584,7 @@
         MaxLength: 21,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 21
           }
@@ -5606,12 +5606,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 21
           }
@@ -5642,12 +5642,12 @@
         MaxLength: 25,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 21
           }
@@ -5669,17 +5669,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 21
           }
@@ -5710,12 +5710,12 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -5737,17 +5737,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -5778,7 +5778,7 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 18
           }
@@ -5800,12 +5800,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 18
           }
@@ -5836,12 +5836,12 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -5863,17 +5863,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -5904,17 +5904,17 @@
         MaxLength: 27,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 3
           }
@@ -5936,22 +5936,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 3
           }
@@ -5982,7 +5982,7 @@
         MaxLength: 14,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 14
           }
@@ -6004,12 +6004,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 14
           }
@@ -6040,7 +6040,7 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -6062,12 +6062,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -6098,7 +6098,7 @@
         MaxLength: 15,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 15
           }
@@ -6120,12 +6120,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 15
           }
@@ -6156,7 +6156,7 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -6178,12 +6178,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -6214,17 +6214,17 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -6246,22 +6246,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 12
           }
@@ -6292,12 +6292,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -6319,17 +6319,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -6360,17 +6360,17 @@
         MaxLength: 19,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           }
@@ -6392,22 +6392,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 12
           }
@@ -6438,7 +6438,7 @@
         MaxLength: 21,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 21
           }
@@ -6460,12 +6460,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 21
           }
@@ -6496,12 +6496,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -6523,17 +6523,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -6564,7 +6564,7 @@
         MaxLength: 23,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           }
@@ -6586,12 +6586,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 23
           }
@@ -6622,12 +6622,12 @@
         MaxLength: 24,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -6649,17 +6649,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 22
           }
@@ -6690,7 +6690,7 @@
         MaxLength: 19,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 19
           }
@@ -6712,12 +6712,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 19
           }
@@ -6748,7 +6748,7 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -6770,12 +6770,12 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 20
           }
@@ -6806,17 +6806,17 @@
         MaxLength: 22,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -6838,22 +6838,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 5
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 1
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 16
           }
@@ -6884,12 +6884,12 @@
         MaxLength: 25,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 19
           }
@@ -6911,17 +6911,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 6
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 19
           }
@@ -6952,12 +6952,12 @@
         MaxLength: 18,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 15
           }
@@ -6979,17 +6979,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 3
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 15
           }
@@ -7020,12 +7020,12 @@
         MaxLength: 20,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -7047,17 +7047,17 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 16
           }
@@ -7088,17 +7088,17 @@
         MaxLength: 16,
         Tokens: [
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -7120,22 +7120,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 10
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           }
@@ -7166,17 +7166,17 @@
         MaxLength: 26,
         Tokens: [
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }
@@ -7198,22 +7198,22 @@
             Length: 2
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 2
           },
           {
-            Category: Other, UppercaseLetter,
+            Category: UppercaseLetter,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, Digit,
+            Category: Digit,
             IsFixedLength: true,
             Length: 4
           },
           {
-            Category: Other, AlphaNumeric,
+            Category: AlphaNumeric,
             IsFixedLength: true,
             Length: 18
           }


### PR DESCRIPTION
Removes the obsolete enum member `AsciiCategory.Other`. It has been deprecated since v5.9.0.