### PR TITLE
fix(S3442)!: change visibility of `LimitCountryRule` ctor to private protected

### DIFF
--- a/src/IbanNet/Validation/Rules/LimitCountryRule.cs
+++ b/src/IbanNet/Validation/Rules/LimitCountryRule.cs
@@ -18,7 +18,7 @@ public abstract class LimitCountryRule : IIbanValidationRule
     /// <param name="countryCodes">An enumerable of accepted country codes (2 letter ISO region name)</param>
     /// <param name="paramName">The parameter name of <paramref name="countryCodes" />of derived type.</param>
     /// <param name="isAccepted"></param>
-    protected internal LimitCountryRule(
+    private protected LimitCountryRule(
         IEnumerable<string> countryCodes,
         string paramName,
         bool isAccepted

--- a/test/IbanNet.Tests/PublicApi/.NET_8.0.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_8.0.verified.txt
@@ -412,7 +412,6 @@ namespace IbanNet.Validation.Rules
     }
     public abstract class LimitCountryRule : IbanNet.Validation.Rules.IIbanValidationRule
     {
-        protected LimitCountryRule(System.Collections.Generic.IEnumerable<string> countryCodes, string paramName, bool isAccepted) { }
         public IbanNet.Validation.Results.ValidationRuleResult Validate(IbanNet.Validation.Rules.ValidationRuleContext context) { }
     }
     public sealed class QrIbanRule : IbanNet.Validation.Rules.IIbanValidationRule

--- a/test/IbanNet.Tests/PublicApi/.NET_Framework_4.6.2.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Framework_4.6.2.verified.txt
@@ -397,7 +397,6 @@ namespace IbanNet.Validation.Rules
     }
     public abstract class LimitCountryRule : IbanNet.Validation.Rules.IIbanValidationRule
     {
-        protected LimitCountryRule(System.Collections.Generic.IEnumerable<string> countryCodes, string paramName, bool isAccepted) { }
         public IbanNet.Validation.Results.ValidationRuleResult Validate(IbanNet.Validation.Rules.ValidationRuleContext context) { }
     }
     public sealed class QrIbanRule : IbanNet.Validation.Rules.IIbanValidationRule

--- a/test/IbanNet.Tests/PublicApi/.NET_Framework_4.7.2.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Framework_4.7.2.verified.txt
@@ -397,7 +397,6 @@ namespace IbanNet.Validation.Rules
     }
     public abstract class LimitCountryRule : IbanNet.Validation.Rules.IIbanValidationRule
     {
-        protected LimitCountryRule(System.Collections.Generic.IEnumerable<string> countryCodes, string paramName, bool isAccepted) { }
         public IbanNet.Validation.Results.ValidationRuleResult Validate(IbanNet.Validation.Rules.ValidationRuleContext context) { }
     }
     public sealed class QrIbanRule : IbanNet.Validation.Rules.IIbanValidationRule

--- a/test/IbanNet.Tests/PublicApi/.NET_Standard_2.0_via_.NET_Framework_4.8.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Standard_2.0_via_.NET_Framework_4.8.verified.txt
@@ -397,7 +397,6 @@ namespace IbanNet.Validation.Rules
     }
     public abstract class LimitCountryRule : IbanNet.Validation.Rules.IIbanValidationRule
     {
-        protected LimitCountryRule(System.Collections.Generic.IEnumerable<string> countryCodes, string paramName, bool isAccepted) { }
         public IbanNet.Validation.Results.ValidationRuleResult Validate(IbanNet.Validation.Rules.ValidationRuleContext context) { }
     }
     public sealed class QrIbanRule : IbanNet.Validation.Rules.IIbanValidationRule

--- a/test/IbanNet.Tests/PublicApi/.NET_Standard_2.1_via_.NET_6.0.verified.txt
+++ b/test/IbanNet.Tests/PublicApi/.NET_Standard_2.1_via_.NET_6.0.verified.txt
@@ -408,7 +408,6 @@ namespace IbanNet.Validation.Rules
     }
     public abstract class LimitCountryRule : IbanNet.Validation.Rules.IIbanValidationRule
     {
-        protected LimitCountryRule(System.Collections.Generic.IEnumerable<string> countryCodes, string paramName, bool isAccepted) { }
         public IbanNet.Validation.Results.ValidationRuleResult Validate(IbanNet.Validation.Rules.ValidationRuleContext context) { }
     }
     public sealed class QrIbanRule : IbanNet.Validation.Rules.IIbanValidationRule


### PR DESCRIPTION
Fixes STA warning [S3442](https://sonarcloud.io/project/issues?impactSoftwareQualities=MAINTAINABILITY&issueStatuses=OPEN%2CCONFIRMED&id=skwasjer_IbanNet&open=AYoxeLRSvpvkshn76rLj) and removes the ctor from `LimitCountryRule` from the public API.

This ctor was never intended to be publicly visible. The `internal` keyword however has no effect when combined with `protected`.