### PR TITLE
perf: improve mod-97,10 by reducing the number of modulo arithmetic operations

### DIFF
--- a/src/IbanNet/CheckDigits/Calculators/Mod97CheckDigitsCalculator.cs
+++ b/src/IbanNet/CheckDigits/Calculators/Mod97CheckDigitsCalculator.cs
@@ -1,4 +1,5 @@
-﻿using IbanNet.Extensions;
+﻿using System.Runtime.CompilerServices;
+using IbanNet.Extensions;
 
 namespace IbanNet.CheckDigits.Calculators;
 
@@ -7,6 +8,9 @@ namespace IbanNet.CheckDigits.Calculators;
 /// </summary>
 public class Mod97CheckDigitsCalculator : ICheckDigitsCalculator
 {
+    private const int MaxDigitsBeforeIntegerOverflow = 8;
+    private const int Modulo = 97;
+
     /// <inheritdoc />
     public int Compute(char[] value)
     {
@@ -15,33 +19,67 @@ public class Mod97CheckDigitsCalculator : ICheckDigitsCalculator
             throw new ArgumentNullException(nameof(value));
         }
 
-        uint current = 0;
+        int digits = 0;
+        int remainder = 0;
         int length = value.Length;
 
         // ReSharper disable once ForCanBeConvertedToForeach - justification : performance
         for (int i = 0; i < length; i++)
         {
             char ch = value[i];
-            if (char.IsAsciiDigit(ch))
-            {
-                // - Shift by 1 digit
-                // - Subtract '0' to get value 0, 1, 2.
-                current = unchecked(((current * 10) + ch - '0') % 97);
-            }
-            else if (char.IsAsciiLetter(ch))
-            {
-                // - For letters, always is two digits so shift 2 digits.
-                // - Use bitwise OR with ' ' (space, 0x20) to convert char to lowercase.
-                // - Then subtract 'a' to get value 0, 1, 2, etc.
-                // - Last, add 10 so: - a = 10, b = 11, c = 12, etc.
-                current = unchecked(((current * 100) + (uint)(ch | ' ') - 'a' + 10) % 97);
-            }
-            else
+            int number = FromBase36(ch);
+            if (number < 0)
             {
                 throw new InvalidTokenException(i, ch);
             }
+
+            // If the number we got is a two-digit number (i.e. >= 10) we need to shift left by 100, else by 10.
+            int numberDigits = 2;
+            int base10Shift = 100;
+            if (number < 10)
+            {
+                numberDigits = 1;
+                base10Shift = 10;
+            }
+
+            remainder = remainder * base10Shift + number;
+            if (digits + numberDigits >= MaxDigitsBeforeIntegerOverflow)
+            {
+                // Compute the new remainder to avoid integer overflow and reset the number of digits.
+                remainder %= Modulo;
+                digits = remainder < 10 ? 1 : 2;
+            }
+            else
+            {
+                digits += numberDigits;
+            }
         }
 
-        return (int)current;
+        if (remainder >= Modulo)
+        {
+            remainder %= Modulo;
+        }
+
+        return remainder;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int FromBase36(char ch)
+    {
+        if (char.IsAsciiDigit(ch))
+        {
+            // Subtract '0' to get value 0, 1, 2.
+            return ch - '0';
+        }
+
+        if (char.IsAsciiLetter(ch))
+        {
+            // - Use bitwise OR with ' ' (space, 0x20) to convert char to lowercase.
+            // - Then subtract 'a' to get value 0, 1, 2, etc.
+            // - Last, add 10 so: - a = 10, b = 11, c = 12, etc.
+            return (ch | ' ') - 'a' + 10;
+        }
+
+        return -1;
     }
 }

--- a/test/IbanNet.Benchmark/BenchmarkResults.md
+++ b/test/IbanNet.Benchmark/BenchmarkResults.md
@@ -5,18 +5,18 @@
 A single validation:
 
 ```
-BenchmarkDotNet v0.15.2, Windows 10 (10.0.19045.6332/22H2/2022Update)
+BenchmarkDotNet v0.15.7, Windows 10 (10.0.19045.6575/22H2/2022Update)
 Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
-.NET SDK 10.0.100-preview.7.25380.108
-  [Host]     : .NET 8.0.20 (8.0.2025.41914), X64 RyuJIT AVX2
-  Job-YQLAGV : .NET 8.0.20 (8.0.2025.41914), X64 RyuJIT AVX2
-  Job-OWJQPM : .NET Framework 4.8.1 (4.8.9310.0), X64 RyuJIT VectorSize=256
+.NET SDK 10.0.100
+  [Host]             : .NET 8.0.22 (8.0.22, 8.0.2225.52707), X64 RyuJIT x86-64-v3
+  .NET 8.0           : .NET 8.0.22 (8.0.22, 8.0.2225.52707), X64 RyuJIT x86-64-v3
+  .NET Framework 4.8 : .NET Framework 4.8.1 (4.8.9310.0), X64 RyuJIT VectorSize=256
 ```
 
-| Method   | Runtime            | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
-|--------- |------------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
-| Validate | .NET 8.0           | 183.4 ns | 1.12 ns | 0.87 ns |  1.00 |    0.01 | 0.0203 |     128 B |        1.00 |
-| Validate | .NET Framework 4.8 | 313.6 ns | 2.72 ns | 2.54 ns |  1.71 |    0.02 | 0.0200 |     128 B |        1.00 |
+| Method   | Job                | Runtime            | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|--------- |------------------- |------------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
+| Validate | .NET 8.0           | .NET 8.0           | 185.0 ns | 0.80 ns | 0.63 ns |  1.00 |    0.00 | 0.0203 |     128 B |        1.00 |
+| Validate | .NET Framework 4.8 | .NET Framework 4.8 | 288.3 ns | 3.98 ns | 3.32 ns |  1.56 |    0.02 | 0.0200 |     128 B |        1.00 |
 
 
 ### Bulk (10k) runs
@@ -28,25 +28,25 @@ This benchmark validates 10,000 IBANs in a loop. It demonstrates the cost of reu
 - *Singleton*: strict validation, singleton validator
 - *Transient*: strict validation, transient validator (per validation). Notice the extra allocations/GC. This is not recommended, and purely for demonstration.
 
-| Method    | Runtime            | Count | Mean     | Error     | StdDev    | Ratio | RatioSD | Gen0      | Allocated | Alloc Ratio |
-|---------- |------------------- |------ |---------:|----------:|----------:|------:|--------:|----------:|----------:|------------:|
-| Singleton | .NET 8.0           | 10000 | 2.919 ms | 0.0289 ms | 0.0256 ms |  1.00 |    0.01 |  207.0313 |   1.24 MB |        1.00 |
-| Singleton | .NET Framework 4.8 | 10000 | 4.075 ms | 0.0188 ms | 0.0176 ms |  1.40 |    0.01 |  203.1250 |   1.25 MB |        1.00 |
-| Transient | .NET 8.0           | 10000 | 5.352 ms | 0.0480 ms | 0.0401 ms |  1.83 |    0.02 | 1125.0000 |   6.74 MB |        5.41 |
-| Transient | .NET Framework 4.8 | 10000 | 7.141 ms | 0.0462 ms | 0.0386 ms |  2.45 |    0.02 | 1210.9375 |   7.29 MB |        5.86 |
+| Method    | Job                | Runtime            | Count | Mean     | Error     | StdDev    | Ratio | RatioSD | Gen0      | Allocated | Alloc Ratio |
+|---------- |------------------- |------------------- |------ |---------:|----------:|----------:|------:|--------:|----------:|----------:|------------:|
+| Singleton | .NET 8.0           | .NET 8.0           | 10000 | 2.540 ms | 0.0231 ms | 0.0181 ms |  1.00 |    0.01 |  207.0313 |   1.24 MB |        1.00 |
+| Singleton | .NET Framework 4.8 | .NET Framework 4.8 | 10000 | 4.158 ms | 0.0171 ms | 0.0152 ms |  1.64 |    0.01 |  203.1250 |   1.25 MB |        1.00 |
+| Transient | .NET 8.0           | .NET 8.0           | 10000 | 5.208 ms | 0.0713 ms | 0.0632 ms |  2.05 |    0.03 | 1125.0000 |   6.74 MB |        5.41 |
+| Transient | .NET Framework 4.8 | .NET Framework 4.8 | 10000 | 7.654 ms | 0.1526 ms | 0.2420 ms |  3.01 |    0.10 | 1210.9375 |   7.29 MB |        5.86 |
 
 
 ### Validation per provider
 
 Validating with `SwiftRegistryProvider` is faster and allocates less memory than the `WikipediaRegistryProvider`, because the pattern matcher is unrolled instead of depending on a more generic match implementation (using an iterator).
 
-| Method   | Runtime            | args      | Mean     | Error   | StdDev   | Median   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
-|--------- |------------------- |---------- |---------:|--------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
-| Validate | .NET 8.0           | Swift     | 163.7 ns | 4.10 ns | 12.10 ns | 155.7 ns |  1.01 |    0.10 | 0.0191 |     120 B |        1.00 |
-| Validate | .NET Framework 4.8 | Swift     | 280.7 ns | 1.40 ns |  1.24 ns | 281.3 ns |  1.72 |    0.12 | 0.0191 |     120 B |        1.00 |
-|          |                    |           |          |         |          |          |       |         |        |           |             |
-| Validate | .NET 8.0           | Wikipedia | 187.3 ns | 0.96 ns |  0.85 ns | 187.5 ns |  1.00 |    0.01 | 0.0191 |     120 B |        1.00 |
-| Validate | .NET Framework 4.8 | Wikipedia | 363.1 ns | 2.28 ns |  2.13 ns | 363.3 ns |  1.94 |    0.01 | 0.0191 |     120 B |        1.00 |
+| Method   | Job                | Runtime            | args      | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|--------- |------------------- |------------------- |---------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
+| Validate | .NET 8.0           | .NET 8.0           | Swift     | 153.2 ns | 0.98 ns | 0.92 ns |  1.00 |    0.01 | 0.0191 |     120 B |        1.00 |
+| Validate | .NET Framework 4.8 | .NET Framework 4.8 | Swift     | 274.8 ns | 2.72 ns | 2.41 ns |  1.79 |    0.02 | 0.0191 |     120 B |        1.00 |
+|          |                    |                    |           |          |         |         |       |         |        |           |             |
+| Validate | .NET 8.0           | .NET 8.0           | Wikipedia | 187.1 ns | 1.20 ns | 1.12 ns |  1.00 |    0.01 | 0.0191 |     120 B |        1.00 |
+| Validate | .NET Framework 4.8 | .NET Framework 4.8 | Wikipedia | 359.1 ns | 5.76 ns | 4.81 ns |  1.92 |    0.03 | 0.0191 |     120 B |        1.00 |
 
 
 ### Initialize registry
@@ -83,6 +83,18 @@ The registry lazy loads definitions. This benchmark only measures the cost of th
 | Lookup | .NET 8.0           | Wikipedia, warm |      8.401 ns |   0.0482 ns |   0.0451 ns |  1.00 |    0.01 |      - |      - |         - |          NA |
 | Lookup | .NET Framework 4.8 | Wikipedia, warm |     45.350 ns |   0.1471 ns |   0.1304 ns |  5.40 |    0.03 |      - |      - |         - |          NA |
 
+### Mod-97,10
+
+| Method | Job                | Runtime            | buffer           | Mean     | Error    | StdDev   | Ratio | RatioSD | Allocated | Alloc Ratio |
+|------- |------------------- |------------------- |----------------- |---------:|---------:|---------:|------:|--------:|----------:|------------:|
+| Test   | .NET 8.0           | .NET 8.0           | 0123456789012345 | 19.42 ns | 0.377 ns | 0.315 ns |  1.00 |    0.02 |         - |          NA |
+| Test   | .NET Framework 4.8 | .NET Framework 4.8 | 0123456789012345 | 21.79 ns | 0.244 ns | 0.228 ns |  1.12 |    0.02 |         - |          NA |
+|        |                    |                    |                  |          |          |          |       |         |           |             |
+| Test   | .NET 8.0           | .NET 8.0           | 01234567ABCDEFGH | 24.85 ns | 0.103 ns | 0.092 ns |  1.00 |    0.01 |         - |          NA |
+| Test   | .NET Framework 4.8 | .NET Framework 4.8 | 01234567ABCDEFGH | 29.39 ns | 0.151 ns | 0.118 ns |  1.18 |    0.01 |         - |          NA |
+|        |                    |                    |                  |          |          |          |       |         |           |             |
+| Test   | .NET 8.0           | .NET 8.0           | ABCDEFGHIJKLMNOP | 24.73 ns | 0.040 ns | 0.033 ns |  1.00 |    0.00 |         - |          NA |
+| Test   | .NET Framework 4.8 | .NET Framework 4.8 | ABCDEFGHIJKLMNOP | 32.65 ns | 0.182 ns | 0.142 ns |  1.32 |    0.01 |         - |          NA |
 ### CLI
 
 To run the benchmark:

--- a/test/IbanNet.Tests/CheckDigits/Calculators/Mod97CheckDigitsCalculatorTests.cs
+++ b/test/IbanNet.Tests/CheckDigits/Calculators/Mod97CheckDigitsCalculatorTests.cs
@@ -10,9 +10,7 @@ public class Mod97CheckDigitsCalculatorTests
     }
 
     [Theory]
-    [InlineData("BMAG00001299123456BH67", 1)]
-    [InlineData("ABC012", 85)]
-    [InlineData("", 0)]
+    [MemberData(nameof(TestCases))]
     public void Given_value_when_computing_should_return_expected_check_digits(string value, int expectedCheckDigits)
     {
         // Act
@@ -20,6 +18,26 @@ public class Mod97CheckDigitsCalculatorTests
 
         // Assert
         actual.Should().Be(expectedCheckDigits);
+    }
+
+    public static TheoryData<string, int> TestCases
+    {
+        get => new()
+        {
+            { "", 0 },
+            { "0", 0 },
+            { "A", 10 },
+            { "Z", 35 },
+            { "ABCDEFG", 27 },
+            { "1234567890", 2 },
+            { "209876541320987654130", 51 },
+            { "1234567890ZYX", 19 },
+            { "65242074034895615069018425766175325148134413755480937177823183347306537990349539826366434011349528759099450602366561132678465015", 16 },
+            { "ABNA0417164300NL91", 1 },
+            { "MALT011000012345MTLCAST001SMT84", 1 },
+            { "BMAG00001299123456BH67", 1 },
+            { "ABC012", 85 }
+        };
     }
 
     [Fact]


### PR DESCRIPTION
Before applying modulo, pack as much digits as we can into an integer. We can save some time this way since the modulo operation is relatively expensive, and now we only have to do it every 8-9 digits.

The `.Compute()` method is anywhere from 50% to 80% faster (compared to `main` branch). It is nanoseconds of course, but going from 50ns to 30ns is still a big win to me. Included the results now for future reference.

> We can also reduce allocations by using `ReadOnlySpan<char>` (and `unsafe char *` in .NET Framework), but this requires an API change or removing this calculator from the public API completely so we can use spans/pointers in more places throughout IbanNet. Additionally, by internalizing this type we can also remove some runtime assertions since we are then guaranteed of the input since previous validation rules would have already validated the input is in expected format (base36). 