### PR TITLE
Alternative implemention of the Mod97-10 calculation

### DIFF
--- a/test/IbanNet.Benchmark/AltMod.cs
+++ b/test/IbanNet.Benchmark/AltMod.cs
@@ -1,0 +1,39 @@
+﻿using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
+
+namespace IbanNet.Benchmark;
+
+internal static class AltMod
+{ 
+    /// <summary>Checks the Mod97 constraint.</summary>
+    [Pure]
+    public static int Mod97(char[] iban)
+    {
+        ulong num = 0;
+
+        // Calculate the first 4 characters (country and checksum) last
+        for (var i = 4; i < iban.Length; i++)
+        {
+            num = Next(num, iban[i]);
+
+            // If we wait longer, we could overflow.
+            if (num >> 57 is not 0) num %= 97;
+        }
+
+        // If we wait longer, we could overflow.
+        if (num >> 44 is not 0) num %= 97;
+
+        for (var i = 0; i < 4; i++)
+        {
+            num = Next(num, iban[i]);
+        }
+
+        return (int)(num % 97);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static ulong Next(ulong num, char ch)
+            => ch <= '9'
+            ? (num * 10) + ch - '0'
+            : (num * 100) + ch - 'A' + 10;
+    }
+}

--- a/test/IbanNet.Benchmark/Mod9710Benchmark.cs
+++ b/test/IbanNet.Benchmark/Mod9710Benchmark.cs
@@ -21,11 +21,18 @@ public class Mod9710Benchmark
         ];
     }
 
+    [Benchmark(Baseline = true)]
+    [ArgumentsSource(nameof(TestCases))]
+    public int Test(TestCase buffer)
+    {
+        return Mod9710.Compute(buffer.Buffer);
+    }
+
     [Benchmark]
     [ArgumentsSource(nameof(TestCases))]
-    public void Test(TestCase buffer)
+    public int Alt(TestCase buffer)
     {
-        Mod9710.Compute(buffer.Buffer);
+        return AltMod.Mod97(buffer.Buffer);
     }
 
     public sealed class TestCase


### PR DESCRIPTION
Recently, I stumbled on your IBAN project when I was searching for other IBAN validators/implementations. While setting up a benchmark between your and mine implementation, I also got an idea to improve the Mod97-10 implementation. (Later, I saw you tried something a bit similar).

Anyhow, My implementation is about twice as fast. So feel free to update the implementation.

| Method | buffer           | Mean      | Error     | StdDev    | Ratio | RatioSD |
|------- |----------------- |----------:|----------:|----------:|------:|--------:|
| Alt    | 0123456789012345 |  8.358 ns | 0.1446 ns | 0.1208 ns |  0.56 |    0.01 |
| Test   | 0123456789012345 | 14.988 ns | 0.3232 ns | 0.3319 ns |  1.00 |    0.03 |
|        |                  |           |           |           |       |         |
| Alt    | 01234567ABCDEFGH | 13.671 ns | 0.2255 ns | 0.2109 ns |  0.54 |    0.01 |
| Test   | 01234567ABCDEFGH | 25.146 ns | 0.2365 ns | 0.2212 ns |  1.00 |    0.01 |
|        |                  |           |           |           |       |         |
| Alt    | ABCDEFGHIJKLMNOP |  9.165 ns | 0.0738 ns | 0.0691 ns |  0.49 |    0.01 |
| Test   | ABCDEFGHIJKLMNOP | 18.896 ns | 0.2695 ns | 0.2521 ns |  1.00 |    0.02 |


So why is this faster?
1. This code performs less (expensive) mod operations
2. This code performs a cheaper way (shift right and equals zero) to check if mod is required
3. This code has two loops to ensure the the last 4 digits are checked last (no branching, less operations)
4. It assumes that all characters are either uppercase ASCI letters, or digits.

If I use  the following code to overcome point 4, the instead of 0.5, the ratio is between 0.65 and 0.60.
``` csharp
        [MethodImpl(MethodImplOptions.AggressiveInlining)]
        static ulong Next(ulong num, char ch, int cursor) => ch switch
        {
            >= '0' and <= '9' => (num * 10) + ch - '0',
            >= 'A' and <= 'Z' => (num * 100) + ch - 'A' + 10,
            >= 'a' and <= 'z' => (num * 100) + ch - 'a' + 10,
            _ => throw new InvalidTokenException(cursor, ch),
        };
```

https://github.com/Qowaiv/Qowaiv/pull/572