### PR TITLE
test: use uninitialized object instead of parsing

### DIFF
--- a/test/IbanNet.Tests/Json/IbanJsonConverterTests.cs
+++ b/test/IbanNet.Tests/Json/IbanJsonConverterTests.cs
@@ -1,4 +1,5 @@
 ﻿#if NET5_0_OR_GREATER
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using IbanNet.Registry;
@@ -108,9 +109,8 @@ public class IbanJsonConverterTests
 
     public static IEnumerable<object?[]> WriterNullArgTestCases()
     {
-        var parser = new IbanParser(IbanRegistry.Default);
         var writer = new Utf8JsonWriter(Stream.Null);
-        Iban value = parser.Parse("NL91 ABNA 0417 1643 00");
+        object value = RuntimeHelpers.GetUninitializedObject(typeof(Iban));
         yield return [null, value, nameof(writer)];
         yield return [writer, null, nameof(value)];
     }


### PR DESCRIPTION
This caused false coverage reporting (at least by DotCover) as test data sources are executed by the test runner before a test is run and will cause a validation/mod97, which is then included in the coverage report, even if the test in question is unrelated.