### PR TITLE
ci(deps): update to Java 25

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           node-version: 20
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: "temurin"
           java-version: "25"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "25"
 
       # Install Mono
       - name: Install Mono (Ubuntu)


### PR DESCRIPTION
SonarCloud requires >= Java 21 since July 20th 2026.

https://docs.sonarsource.com/sonarqube-cloud/analyzing-source-code/scanners/scanner-environment/general-requirements